### PR TITLE
Apply clearing lemma in column reduction (closes #4)

### DIFF
--- a/lib/ph_nx/reduction.ex
+++ b/lib/ph_nx/reduction.ex
@@ -57,7 +57,10 @@ defmodule PhNx.Reduction do
       low ->
         case Map.get(pivot_col, low) do
           nil ->
-            # This pivot row is free — record (low, j) as a persistence pair
+            # This pivot row is free — record (low, j) as a persistence pair.
+            # Clearing lemma: column `low` will reduce to zero when reached,
+            # so remove it now to skip that work entirely (O(1) saving per pair).
+            boundary = Map.delete(boundary, low)
             {boundary, Map.put(pivot_col, low, j), [{low, j} | pairs]}
 
           i ->

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -169,6 +169,21 @@ defmodule PhNxTest do
       assert result.essential == [0]
     end
 
+    test "clearing: every birth column is absent from the reduced map" do
+      # For any pair (i, j), column i is pre-cleared after the pair is claimed.
+      # This holds for H0 pairs (vertex birth, empty column) and for H1 pairs
+      # (edge birth, non-empty column) — the edge column must be gone.
+      pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+      d = Distance.euclidean(pts)
+      f = Filtration.build(d, 2)
+      {bnd, _} = BoundaryMatrix.build(f)
+      %{pairs: pairs, reduced: reduced} = Reduction.reduce(bnd, length(f))
+      Enum.each(pairs, fn {i, _j} ->
+        refute Map.has_key?(reduced, i),
+               "birth column #{i} should be cleared after pairing"
+      end)
+    end
+
     test "two isolated vertices: one edge pair kills one H0 class" do
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
       d = Distance.euclidean(pts)


### PR DESCRIPTION
## What this does

Closes #4.

After column `j` claims pivot row `low`, immediately delete column `low` from the boundary map. The clearing lemma guarantees column `low` will reduce to zero when the algorithm reaches it — removing it now is O(1) and skips all future column additions against it.

## Change

One line added to `reduce_column/4` in `PhNx.Reduction`:

```elixir
boundary = Map.delete(boundary, low)
```

## Results (o3_50, max_dim=2, with enclosing-radius threshold from #3)

| Metric | Before | After |
|---|---|---|
| Reduction | 435 ms | 420 ms |

Modest standalone gain; the clearing lemma lays the groundwork for apparent pairs (#5), which eliminates far more columns up-front.

## Test plan

- [x] New test: every birth column `i` is absent from `reduced` after pairing (verifies clearing is applied)
- [x] All 33 tests pass; ripser H₀/H₁ regression unchanged