### PR TITLE
Fix dead code in BoundaryMatrix.lowest/2

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -48,7 +48,6 @@ defmodule PhNx.BoundaryMatrix do
   def lowest(boundary, col) do
     case Map.get(boundary, col) do
       nil -> nil
-      set when map_size(%{}) == 0 -> if MapSet.size(set) == 0, do: nil, else: Enum.max(set)
       set -> if MapSet.size(set) == 0, do: nil, else: Enum.max(set)
     end
   end

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -170,6 +170,10 @@ defmodule PhNxTest do
     test "returns nil for missing column" do
       assert BoundaryMatrix.lowest(%{}, 0) == nil
     end
+
+    test "returns nil for empty column set" do
+      assert BoundaryMatrix.lowest(%{0 => MapSet.new()}, 0) == nil
+    end
   end
 
   describe "BoundaryMatrix.add_columns/3" do


### PR DESCRIPTION
## Summary

- Removes unreachable clause in `BoundaryMatrix.lowest/2` where the guard `map_size(%{})` always evaluates to `0` (it checks a literal empty map, not the bound variable), making the clause a no-op duplicate of the one below it
- Adds a test to explicitly document that a column present in the boundary with an empty `MapSet` returns `nil`

Closes #15

## Test plan

- [x] `mix test` passes (37 tests, 0 failures)
- [x] New test: `"returns nil for empty column set"` covers the previously undocumented contract