### PR TITLE
Lower Elixir version constraint to ~> 1.18 (closes #18)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PhNx.MixProject do
     [
       app: :ph_nx,
       version: "0.1.0",
-      elixir: "~> 1.19",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]


### PR DESCRIPTION
## Summary

- Change `elixir: "~> 1.19"` to `elixir: "~> 1.18"` in `mix.exs`
- No Elixir 1.19-specific language features are used in the codebase
- This was a critical blocker: anyone on Elixir 1.18.x got an immediate version error from `mix test`

## Test plan

- [x] `mix compile` succeeds
- [x] `mix test` passes on Elixir 1.18.x
