### PR TITLE
Raise ArgumentError for empty point cloud in compute/2 (closes #19)

### DIFF
--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -36,6 +36,10 @@ defmodule PhNx.Persistence do
     opts = Keyword.validate!(opts, [:max_dim, :threshold])
     max_dim = Keyword.get(opts, :max_dim, 2)
 
+    if points == [] or (is_list(points) and length(points) == 0) do
+      raise ArgumentError, "point cloud must be non-empty"
+    end
+
     points = if is_list(points), do: Nx.tensor(points, type: :f64), else: points
 
     if Nx.axis_size(points, 0) == 0 do

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -380,6 +380,21 @@ defmodule PhNxTest do
       assert length(result.diagram) == expected_count
     end
 
+    test "empty list raises ArgumentError" do
+      assert_raise ArgumentError, "point cloud must be non-empty", fn ->
+        Persistence.compute([])
+      end
+    end
+
+    test "single-point list does not raise" do
+      assert %{pairs: _, essential: _, diagram: _} = Persistence.compute([[0.0, 0.0]])
+    end
+
+    test "single-point tensor does not raise" do
+      pts = Nx.tensor([[0.0, 0.0]])
+      assert %{pairs: _, essential: _, diagram: _} = Persistence.compute(pts)
+    end
+
     test "unknown option key raises ArgumentError" do
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
       assert_raise ArgumentError, fn -> Persistence.compute(pts, max_dims: 2) end


### PR DESCRIPTION
## Summary

- Add an early guard in `Persistence.compute/2` that raises `ArgumentError` when the point cloud is empty
- Without this guard, `Filtration.build/2` iterates over the range `0..-1` (Elixir 1.18 behaviour), fabricating spurious vertices `0` and `-1`, leading to garbage filtration data or a confusing downstream crash

## Test plan

- [x] `PhNx.compute([], max_dim: 2)` raises `ArgumentError: point cloud must be non-empty`
- [x] `PhNx.compute([[0.0, 0.0], [1.0, 0.0]])` still works normally