### PR TITLE
Correct threshold default documentation (closes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ PhNx.most_persistent(result, 5) # => [{dim, birth, death, persistence}, ...]
 | Option | Default | Description |
 |---|---|---|
 | `:max_dim` | `2` | Maximum simplex dimension. To detect Hₖ features you need simplices up to dimension k+1. |
-| `:threshold` | `:infinity` | Ignore simplices born after this filtration value. |
+| `:threshold` | enclosing radius | Ignore simplices born after this filtration value. The enclosing radius is the smallest value at which all points are connected. Pass `:infinity` to include all simplices. |
 
 ## Modules
 
@@ -83,5 +83,5 @@ PhNx.most_persistent(result, 5) # => [{dim, birth, death, persistence}, ...]
 
 ## Limitations & future work
 
-- **Scale**: reduction is O(m³) worst-case in the number of simplices. For point clouds larger than ~100 points without a threshold, runtime grows quickly. Pass `threshold: t` to `compute/2` to limit the filtration.
+- **Scale**: reduction is O(m³) worst-case in the number of simplices. The default threshold (enclosing radius) limits the filtration automatically, but passing `threshold: :infinity` on large point clouds will grow quickly.
 - **Sparse distance input**: currently only Euclidean point clouds are supported; sparse or precomputed distance matrices could be added.

--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -23,7 +23,10 @@ defmodule PhNx.Persistence do
   Options:
     - `max_dim` (integer, default 2): maximum simplex dimension in the filtration.
       To compute Hₖ you need simplices up to dimension k+1.
-    - `threshold` (float, default :infinity): ignore simplices born after this value.
+    - `threshold` (float, default: enclosing radius of the point cloud): ignore simplices
+      born after this filtration value. The enclosing radius is the smallest value at which
+      all points are connected, so the default produces the most topologically meaningful
+      filtration. Pass `threshold: :infinity` to include all simplices regardless of scale.
 
   Returns a map:
     %{


### PR DESCRIPTION
## Summary

Both the `@doc` for `Persistence.compute/2` and the README options table claimed the default for `:threshold` was `:infinity`. The actual implementation uses `Distance.enclosing_radius/1`, which is the smallest value at which all points are connected — a meaningful, non-trivial default.

**Changes:**
- `@doc`: replace `default :infinity` with an accurate description of the enclosing radius and document `:infinity` as the explicit opt-out
- `README.md` options table: same correction
- `README.md` limitations note: updated to reflect that the default threshold already limits the filtration; `:infinity` is the unbounded case

## Test plan

- [x] `mix test` passes (docs-only change, no logic affected)
- [x] `@doc` for `compute/2` accurately describes the threshold default