### PR TITLE
Move EXLA config to dev.exs, use env-specific config files (closes #23)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,3 @@
 import Config
 
-config :nx, default_backend: EXLA.Backend
-
-config :exla,
-  preferred_clients: [:default],
-  clients: [default: [platform: :host]]
-
-if config_env() == :test, do: import_config "test.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,9 @@
+import Config
+
+# Use EXLA for accelerated computation during development.
+# Requires XLA binaries — see the EXLA README if this fails to start.
+config :nx, default_backend: EXLA.Backend
+
+config :exla,
+  preferred_clients: [:default],
+  clients: [default: [platform: :host]]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+import Config


### PR DESCRIPTION
## Summary

`config/config.exs` was unconditionally setting `EXLA.Backend` as the Nx default, causing failures for anyone developing without XLA binaries compiled.

The test-environment half of this was already fixed (PR #21 added `config/test.exs` with `Nx.BinaryBackend`). This PR completes the fix:

- **`config/config.exs`** — reduced to just `import_config "#{config_env()}.exs"`
- **`config/dev.exs`** — EXLA backend settings (development only)
- **`config/test.exs`** — `Nx.BinaryBackend`, unchanged
- **`config/prod.exs`** — empty; no backend override for library consumers

## Test plan

- [x] `mix test` passes (uses `Nx.BinaryBackend`, no EXLA NIF required)
- [x] `MIX_ENV=prod mix compile` passes