### PR TITLE
Rewrite BoundaryMatrix.to_tensor/2 using Nx.indexed_put (closes #24)

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -73,15 +73,19 @@ defmodule PhNx.BoundaryMatrix do
   Returns an {m, m} tensor over u8.
   """
   def to_tensor(boundary, m) do
-    rows = List.duplicate(List.duplicate(0, m), m)
+    base = Nx.broadcast(Nx.tensor(0, type: :u8), {m, m})
 
-    dense =
-      Enum.reduce(boundary, rows, fn {col, row_set}, acc ->
-        Enum.reduce(row_set, acc, fn row, a ->
-          List.update_at(a, row, fn r -> List.replace_at(r, col, 1) end)
-        end)
+    all_indices =
+      Enum.flat_map(boundary, fn {col, row_set} ->
+        Enum.map(row_set, fn row -> [row, col] end)
       end)
 
-    Nx.tensor(dense, type: :u8)
+    if all_indices == [] do
+      base
+    else
+      indices = Nx.tensor(all_indices)
+      updates = Nx.broadcast(Nx.tensor(1, type: :u8), {length(all_indices)})
+      Nx.indexed_put(base, indices, updates)
+    end
   end
 end

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -190,6 +190,40 @@ defmodule PhNxTest do
     end
   end
 
+  describe "BoundaryMatrix.to_tensor/2" do
+    test "empty boundary produces zero matrix" do
+      t = BoundaryMatrix.to_tensor(%{}, 3)
+      assert Nx.shape(t) == {3, 3}
+      assert Nx.to_list(t) == [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+    end
+
+    test "single entry sets correct cell" do
+      bnd = %{2 => MapSet.new([0, 1])}
+      t = BoundaryMatrix.to_tensor(bnd, 3)
+      mat = Nx.to_list(t)
+      # row 0, col 2 and row 1, col 2 should be 1
+      assert Enum.at(Enum.at(mat, 0), 2) == 1
+      assert Enum.at(Enum.at(mat, 1), 2) == 1
+      # all other cells zero
+      assert Enum.at(Enum.at(mat, 2), 2) == 0
+    end
+
+    test "matches boundary built from a real filtration" do
+      pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+      d = Distance.euclidean(pts)
+      f = Filtration.build(d, 1)
+      {bnd, _} = BoundaryMatrix.build(f)
+      m = length(f)
+      t = BoundaryMatrix.to_tensor(bnd, m)
+      assert Nx.shape(t) == {m, m}
+      # Each edge column should have exactly 2 ones
+      Enum.each(Enum.filter(f, &(&1.dim == 1)), fn %{index: j} ->
+        col = t[[.., j]] |> Nx.to_list()
+        assert Enum.sum(col) == 2
+      end)
+    end
+  end
+
   # ── Apparent pairs ───────────────────────────────────────────────────────────
 
   describe "Reduction.apparent_pairs/2" do


### PR DESCRIPTION
## Summary

`to_tensor/2` was building the dense matrix via nested `List.update_at` calls. Each call is O(n) on a linked list; with O(m²) nonzero entries in an m×m boundary matrix the total was **O(m⁴)**.

Replaced with a single `Nx.indexed_put` over all nonzero `{row, col}` pairs — **O(m²)**.

## Changes

- `lib/ph_nx/boundary_matrix.ex`: collect all nonzero indices with `Enum.flat_map`, then call `Nx.indexed_put` once on a zero base tensor
- `test/ph_nx_test.exs`: three new tests — empty matrix, single nonzero column, and column-sum consistency against a real filtration

## Test plan

- [x] `mix test` passes (60 tests)
- [x] `BoundaryMatrix.to_tensor(%{}, 3)` returns a 3×3 zero tensor
- [x] Column sums for edge columns equal 2 (two boundary vertices)