### PR TITLE
Fix O(n³) sorted_edges and document as public utility (closes #25, closes #26)

### DIFF
--- a/lib/ph_nx/distance.ex
+++ b/lib/ph_nx/distance.ex
@@ -51,15 +51,20 @@ defmodule PhNx.Distance do
   @doc """
   Extract the upper-triangular entries of a distance matrix as `{i, j, dist}` triples,
   sorted by distance ascending.
+
+  Useful as a user-facing utility for inspecting the edge order of a Vietoris-Rips
+  filtration without building the full filtration.
+
+  Uses a flat-tuple representation for O(1) per-pair access, giving O(n²) total
+  rather than the O(n³) cost of nested list traversals.
   """
   def sorted_edges(dist_matrix) do
     n = Nx.axis_size(dist_matrix, 0)
-    mat = Nx.to_list(dist_matrix)
+    dist_flat = dist_matrix |> Nx.to_list() |> Enum.concat() |> List.to_tuple()
 
     for i <- 0..(n - 2),
         j <- (i + 1)..(n - 1) do
-      d = mat |> Enum.at(i) |> Enum.at(j)
-      {i, j, d}
+      {i, j, elem(dist_flat, i * n + j)}
     end
     |> Enum.sort_by(fn {_, _, d} -> d end)
   end

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -49,6 +49,22 @@ defmodule PhNxTest do
       dists = Enum.map(edges, fn {_, _, x} -> x end)
       assert dists == Enum.sort(dists)
     end
+
+    test "returns n*(n-1)/2 edges for n points" do
+      pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+      d = Distance.euclidean(pts)
+      edges = Distance.sorted_edges(d)
+      assert length(edges) == 6
+    end
+
+    test "each edge {i, j, dist} has i < j and correct distance" do
+      pts = Nx.tensor([[0.0, 0.0], [3.0, 4.0]])
+      d = Distance.euclidean(pts)
+      [{i, j, dist}] = Distance.sorted_edges(d)
+      assert i == 0
+      assert j == 1
+      assert_in_delta dist, 5.0, 1.0e-9
+    end
   end
 
   # ── Filtration ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes two issues with `Distance.sorted_edges/1` in a single change.

**#25 — O(n³) performance:**
`Enum.at` on a linked list is O(index). The previous implementation called it twice per `(i, j)` pair, making the full traversal O(n³). Replaced with the flat-tuple pattern already used in `Filtration.build/2`: convert the distance matrix to a flat tuple once (O(n²)), then use `elem/2` for O(1) per-pair access — O(n²) total.

**#26 — Undocumented public API:**
The function was public but had no context explaining why a caller would use it. Added a `@doc` note clarifying its purpose as a user-facing utility for inspecting the edge order of a filtration without building the full filtration struct.

## Changes

- `lib/ph_nx/distance.ex`: rewrite using flat-tuple access; expand `@doc`
- `test/ph_nx_test.exs`: two new tests — edge count (`n*(n-1)/2`) and correct `{i, j, dist}` values for a known pair

## Test plan

- [x] `mix test` passes (62 tests)
- [x] `sorted_edges` on 4 points returns 6 edges
- [x] `sorted_edges` on 2 points returns `{0, 1, 5.0}` for a 3-4-5 triangle