### PR TITLE
Remove identity map in diagram construction (closes #28)

### DIFF
--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -92,8 +92,7 @@ defmodule PhNx.Persistence do
       |> Enum.sort()
 
     diagram =
-      (Enum.map(pairs, fn {d, b, death} -> {d, b, death} end) ++
-         Enum.map(essential, fn {d, b} -> {d, b, :infinity} end))
+      (pairs ++ Enum.map(essential, fn {d, b} -> {d, b, :infinity} end))
       |> Enum.sort()
 
     %{pairs: pairs, essential: essential, diagram: diagram}


### PR DESCRIPTION
## Summary

`Persistence.compute/2` was constructing the diagram with:

```elixir
Enum.map(pairs, fn {d, b, death} -> {d, b, death} end) ++ ...
```

This is an identity map — `pairs` is already `[{dim, birth, death}]`, so the `Enum.map` allocates a new list with identical contents and does nothing useful. Replaced with `pairs` directly.

## Test plan

- [x] `mix test` passes (62 tests, diagram construction covered by existing tests)