### PR TITLE
Add @spec annotations and @type definitions to all public functions (closes #29)

### DIFF
--- a/lib/ph_nx.ex
+++ b/lib/ph_nx.ex
@@ -24,8 +24,17 @@ defmodule PhNx do
     - `PhNx.Persistence`    — high-level API and output formatting
   """
 
+  @spec compute(Nx.Tensor.t() | [[number()]], keyword()) :: PhNx.Persistence.result()
   defdelegate compute(points, opts \\ []), to: PhNx.Persistence
+
+  @spec print_barcode(PhNx.Persistence.result()) :: :ok
   defdelegate print_barcode(result), to: PhNx.Persistence
+
+  @spec most_persistent(PhNx.Persistence.result(), pos_integer()) ::
+          [{non_neg_integer(), float(), float(), float()}]
   defdelegate most_persistent(result, n \\ 10), to: PhNx.Persistence
+
+  @spec betti_numbers(PhNx.Persistence.result()) ::
+          %{optional(non_neg_integer()) => non_neg_integer()}
   defdelegate betti_numbers(result), to: PhNx.Persistence
 end

--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -11,12 +11,16 @@ defmodule PhNx.BoundaryMatrix do
 
   alias PhNx.Filtration
 
+  @typedoc "Sparse boundary matrix over F₂: maps column index to the set of nonzero row indices."
+  @type t :: %{optional(non_neg_integer()) => MapSet.t(non_neg_integer())}
+
   @doc """
   Build the sparse boundary matrix from a filtration.
 
   Returns `{boundary_matrix, filtration}` where `boundary_matrix` is
   `%{non_neg_integer() => MapSet.t(non_neg_integer())}`.
   """
+  @spec build([Filtration.simplex()]) :: {t(), [Filtration.simplex()]}
   def build(filtration) do
     index_map = Filtration.index_map(filtration)
 
@@ -45,6 +49,7 @@ defmodule PhNx.BoundaryMatrix do
   @doc """
   Return the lowest (maximum) row index in column `col`, or `nil` if the column is zero.
   """
+  @spec lowest(t(), non_neg_integer()) :: non_neg_integer() | nil
   def lowest(boundary, col) do
     case Map.get(boundary, col) do
       nil -> nil
@@ -56,6 +61,7 @@ defmodule PhNx.BoundaryMatrix do
   Add column `src` to column `dst` over F₂ (symmetric difference of their row sets).
   Returns updated boundary matrix.
   """
+  @spec add_columns(t(), non_neg_integer(), non_neg_integer()) :: t()
   def add_columns(boundary, dst, src) do
     col_dst = Map.get(boundary, dst, MapSet.new())
     col_src = Map.get(boundary, src, MapSet.new())
@@ -72,6 +78,7 @@ defmodule PhNx.BoundaryMatrix do
   Convert the sparse boundary matrix to a dense Nx tensor for inspection/visualization.
   Returns an {m, m} tensor over u8.
   """
+  @spec to_tensor(t(), non_neg_integer()) :: Nx.Tensor.t()
   def to_tensor(boundary, m) do
     base = Nx.broadcast(Nx.tensor(0, type: :u8), {m, m})
 

--- a/lib/ph_nx/distance.ex
+++ b/lib/ph_nx/distance.ex
@@ -16,6 +16,7 @@ defmodule PhNx.Distance do
       iex> PhNx.Distance.euclidean(points)
       #Nx.Tensor<...>
   """
+  @spec euclidean(Nx.Tensor.t()) :: Nx.Tensor.t()
   def euclidean(points) do
     points = Nx.as_type(points, :f64)
     euclidean_n(points)
@@ -41,6 +42,7 @@ defmodule PhNx.Distance do
   Above this scale no new topology can appear, so the Vietoris-Rips filtration can be
   safely truncated here.
   """
+  @spec enclosing_radius(Nx.Tensor.t()) :: float()
   def enclosing_radius(dist_matrix) do
     dist_matrix
     |> Nx.reduce_max(axes: [1])
@@ -58,6 +60,7 @@ defmodule PhNx.Distance do
   Uses a flat-tuple representation for O(1) per-pair access, giving O(n²) total
   rather than the O(n³) cost of nested list traversals.
   """
+  @spec sorted_edges(Nx.Tensor.t()) :: [{non_neg_integer(), non_neg_integer(), float()}]
   def sorted_edges(dist_matrix) do
     n = Nx.axis_size(dist_matrix, 0)
     dist_flat = dist_matrix |> Nx.to_list() |> Enum.concat() |> List.to_tuple()

--- a/lib/ph_nx/filtration.ex
+++ b/lib/ph_nx/filtration.ex
@@ -18,12 +18,21 @@ defmodule PhNx.Filtration do
   O(1) access per pair via `elem/2` instead of O(n) nested `Enum.at` traversals.
   """
 
+  @typedoc "A simplex in the filtration, with its vertex set, dimension, birth time, and index."
+  @type simplex :: %{
+          vertices: [non_neg_integer()],
+          dim: non_neg_integer(),
+          birth: float(),
+          index: non_neg_integer()
+        }
+
   @doc """
   Build a Vietoris-Rips filtration up to `max_dim` from a precomputed distance matrix.
 
   `dist_matrix` is an n×n Nx tensor (or list-of-lists). `max_dim` controls the maximum
   simplex dimension included (0 = vertices only, 1 = edges, 2 = triangles, etc.).
   """
+  @spec build(Nx.Tensor.t(), non_neg_integer()) :: [simplex()]
   def build(dist_matrix, max_dim \\ 2) do
     n = Nx.axis_size(dist_matrix, 0)
 
@@ -76,6 +85,7 @@ defmodule PhNx.Filtration do
   @doc """
   Return all (k-1)-faces of a k-simplex (as sorted vertex lists).
   """
+  @spec faces(simplex()) :: [[non_neg_integer()]]
   def faces(%{vertices: vertices}) do
     vertices
     |> Enum.with_index()
@@ -87,6 +97,7 @@ defmodule PhNx.Filtration do
   @doc """
   Build a lookup map from vertex list to filtration index.
   """
+  @spec index_map([simplex()]) :: %{optional([non_neg_integer()]) => non_neg_integer()}
   def index_map(filtration) do
     Map.new(filtration, fn %{vertices: v, index: i} -> {v, i} end)
   end

--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -17,6 +17,22 @@ defmodule PhNx.Persistence do
 
   alias PhNx.{Distance, Filtration, BoundaryMatrix, Reduction}
 
+  @typedoc "A finite persistence pair: {dimension, birth, death}."
+  @type pair :: {non_neg_integer(), float(), float()}
+
+  @typedoc "An essential (infinite) homology class: {dimension, birth}."
+  @type essential_class :: {non_neg_integer(), float()}
+
+  @typedoc "A diagram entry: finite pair or essential class extended to :infinity."
+  @type diagram_entry :: {non_neg_integer(), float(), float() | :infinity}
+
+  @typedoc "The result map returned by `compute/2`."
+  @type result :: %{
+          pairs: [pair()],
+          essential: [essential_class()],
+          diagram: [diagram_entry()]
+        }
+
   @doc """
   Compute persistent homology for a point cloud.
 
@@ -35,6 +51,7 @@ defmodule PhNx.Persistence do
       diagram:   [{dim, birth, death | :infinity}]  # union of pairs + essential
     }
   """
+  @spec compute(Nx.Tensor.t() | [[number()]], keyword()) :: result()
   def compute(points, opts \\ []) do
     opts = Keyword.validate!(opts, [:max_dim, :threshold])
     max_dim = Keyword.get(opts, :max_dim, 2)
@@ -107,6 +124,7 @@ defmodule PhNx.Persistence do
   @doc """
   Print a human-readable barcode summary.
   """
+  @spec print_barcode(result()) :: :ok
   def print_barcode(%{diagram: diagram}) do
     IO.puts("\nPersistence Barcode")
     IO.puts(String.duplicate("─", 50))
@@ -136,6 +154,7 @@ defmodule PhNx.Persistence do
   Return persistence pairs sorted by persistence (death - birth) descending.
   Useful for identifying the most significant topological features.
   """
+  @spec most_persistent(result(), pos_integer()) :: [{non_neg_integer(), float(), float(), float()}]
   def most_persistent(%{pairs: pairs}, n \\ 10) do
     pairs
     |> Enum.map(fn {dim, birth, death} -> {dim, birth, death, death - birth} end)
@@ -147,6 +166,7 @@ defmodule PhNx.Persistence do
   Compute Betti numbers from the essential classes.
   Returns a map `%{dimension => count}`.
   """
+  @spec betti_numbers(result()) :: %{optional(non_neg_integer()) => non_neg_integer()}
   def betti_numbers(%{essential: essential}) do
     essential
     |> Enum.group_by(fn {d, _} -> d end)

--- a/lib/ph_nx/reduction.ex
+++ b/lib/ph_nx/reduction.ex
@@ -18,6 +18,16 @@ defmodule PhNx.Reduction do
 
   alias PhNx.{BoundaryMatrix, Filtration}
 
+  @typedoc "A raw index pair {birth_index, death_index} from the reduction."
+  @type index_pair :: {non_neg_integer(), non_neg_integer()}
+
+  @typedoc "Result of the reduction: raw index pairs, essential simplex indices, and the reduced matrix."
+  @type reduction_result :: %{
+          pairs: [index_pair()],
+          essential: [non_neg_integer()],
+          reduced: BoundaryMatrix.t()
+        }
+
   @doc """
   Pre-pass: identify apparent pairs from the boundary matrix and filtration.
 
@@ -32,6 +42,8 @@ defmodule PhNx.Reduction do
 
   Returns `{pairs, boundary}` where apparent pairs are pre-recorded.
   """
+  @spec apparent_pairs(BoundaryMatrix.t(), [Filtration.simplex()]) ::
+          {[index_pair()], BoundaryMatrix.t()}
   def apparent_pairs(boundary, filtration) do
     coface_map = build_coface_map(filtration)
 
@@ -81,6 +93,8 @@ defmodule PhNx.Reduction do
 
   where `i` and `j` are filtration indices.
   """
+  @spec reduce(BoundaryMatrix.t(), non_neg_integer(), [Filtration.simplex()] | nil) ::
+          reduction_result()
   def reduce(boundary, filtration_size, filtration \\ nil) do
     {ap_pairs, boundary} =
       if filtration, do: apparent_pairs(boundary, filtration), else: {[], boundary}


### PR DESCRIPTION
## Summary

Adds `@spec` to every public function across all modules, and introduces shared `@type` definitions so the data flow is machine-checkable by Dialyzer.

### Types added

| Module | Type | Description |
|--------|------|-------------|
| `PhNx.Filtration` | `simplex()` | `%{vertices, dim, birth, index}` |
| `PhNx.BoundaryMatrix` | `t()` | sparse map over F₂ |
| `PhNx.Reduction` | `index_pair()` | raw `{birth_idx, death_idx}` |
| `PhNx.Reduction` | `reduction_result()` | `%{pairs, essential, reduced}` |
| `PhNx.Persistence` | `pair()` | `{dim, birth, death}` |
| `PhNx.Persistence` | `essential_class()` | `{dim, birth}` |
| `PhNx.Persistence` | `diagram_entry()` | `{dim, birth, death \| :infinity}` |
| `PhNx.Persistence` | `result()` | the `compute/2` return map |

### Specs added

All public functions in `Distance`, `Filtration`, `BoundaryMatrix`, `Reduction`, `Persistence`, and the `PhNx` top-level delegates.

## Test plan

- [x] `mix compile` produces no errors
- [x] `mix test` passes (62 tests)