### PR TITLE
Apply mix format to persistence.ex and ph_nx_test.exs (closes #43)

### DIFF
--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -154,7 +154,9 @@ defmodule PhNx.Persistence do
   Return persistence pairs sorted by persistence (death - birth) descending.
   Useful for identifying the most significant topological features.
   """
-  @spec most_persistent(result(), pos_integer()) :: [{non_neg_integer(), float(), float(), float()}]
+  @spec most_persistent(result(), pos_integer()) :: [
+          {non_neg_integer(), float(), float(), float()}
+        ]
   def most_persistent(%{pairs: pairs}, n \\ 10) do
     pairs
     |> Enum.map(fn {dim, birth, death} -> {dim, birth, death, death - birth} end)

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -447,6 +447,7 @@ defmodule PhNxTest do
 
     test "negative max_dim raises ArgumentError" do
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
+
       assert_raise ArgumentError, ~r/max_dim must be a non-negative integer/, fn ->
         Persistence.compute(pts, max_dim: -1)
       end
@@ -454,6 +455,7 @@ defmodule PhNxTest do
 
     test "float max_dim raises ArgumentError" do
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
+
       assert_raise ArgumentError, ~r/max_dim must be a non-negative integer/, fn ->
         Persistence.compute(pts, max_dim: 1.5)
       end
@@ -480,7 +482,9 @@ defmodule PhNxTest do
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
       assert %{pairs: _, essential: _, diagram: _} = Persistence.compute(pts, max_dim: 1)
       assert %{pairs: _, essential: _, diagram: _} = Persistence.compute(pts, threshold: 2.0)
-      assert %{pairs: _, essential: _, diagram: _} = Persistence.compute(pts, max_dim: 1, threshold: 2.0)
+
+      assert %{pairs: _, essential: _, diagram: _} =
+               Persistence.compute(pts, max_dim: 1, threshold: 2.0)
     end
   end
 


### PR DESCRIPTION
## Summary

- Wraps `@spec most_persistent/2` return type across multiple lines in `lib/ph_nx/persistence.ex`
- Adds missing blank lines after `assert_raise` calls in `test/ph_nx_test.exs`
- Wraps one long assertion line in `test/ph_nx_test.exs`

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix test` — 62 tests, 0 failures