### PR TITLE
Extract duplicate dist_flat logic into Distance.flat_tuple/1 (closes #44)

### DIFF
--- a/lib/ph_nx/distance.ex
+++ b/lib/ph_nx/distance.ex
@@ -51,6 +51,17 @@ defmodule PhNx.Distance do
   end
 
   @doc """
+  Flatten a distance matrix Nx tensor into a tuple for O(1) pair lookups.
+
+  `dist_flat[i*n + j]` gives `dist(i, j)` via `elem/2`.
+  Handles EXLA device-to-host transfer via `Nx.to_list/1`.
+  """
+  @spec flat_tuple(Nx.Tensor.t()) :: tuple()
+  def flat_tuple(dist_matrix) do
+    dist_matrix |> Nx.to_list() |> Enum.concat() |> List.to_tuple()
+  end
+
+  @doc """
   Extract the upper-triangular entries of a distance matrix as `{i, j, dist}` triples,
   sorted by distance ascending.
 
@@ -63,7 +74,7 @@ defmodule PhNx.Distance do
   @spec sorted_edges(Nx.Tensor.t()) :: [{non_neg_integer(), non_neg_integer(), float()}]
   def sorted_edges(dist_matrix) do
     n = Nx.axis_size(dist_matrix, 0)
-    dist_flat = dist_matrix |> Nx.to_list() |> Enum.concat() |> List.to_tuple()
+    dist_flat = flat_tuple(dist_matrix)
 
     for i <- 0..(n - 2),
         j <- (i + 1)..(n - 1) do

--- a/lib/ph_nx/filtration.ex
+++ b/lib/ph_nx/filtration.ex
@@ -37,14 +37,9 @@ defmodule PhNx.Filtration do
     n = Nx.axis_size(dist_matrix, 0)
 
     # Extract the distance matrix into a flat tuple for O(1) pair lookups.
-    # dist_flat[i*n + j] == dist(i, j). Nx.to_list handles EXLA device-to-host
-    # transfer. The Enum.concat + List.to_tuple setup is O(n²) but runs once;
+    # dist_flat[i*n + j] == dist(i, j). The setup is O(n²) but runs once;
     # each per-simplex birth lookup is then O(1) via elem/2 with no allocation.
-    dist_flat =
-      dist_matrix
-      |> Nx.to_list()
-      |> Enum.concat()
-      |> List.to_tuple()
+    dist_flat = PhNx.Distance.flat_tuple(dist_matrix)
 
     vertices = for i <- 0..(n - 1), do: [i]
 


### PR DESCRIPTION
## Summary

- Adds `PhNx.Distance.flat_tuple/1` as a shared helper that flattens an Nx distance matrix into a tuple for O(1) pair lookups
- Replaces the inline duplication in `Distance.sorted_edges/1` and `Filtration.build/2` with a single call to `flat_tuple/1`

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix test` — 62 tests, 0 failures, 0 warnings