### PR TITLE
Add edge case tests: identical points, 1D input, large max_dim (closes #45)

### DIFF
--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -486,6 +486,35 @@ defmodule PhNxTest do
       assert %{pairs: _, essential: _, diagram: _} =
                Persistence.compute(pts, max_dim: 1, threshold: 2.0)
     end
+
+    test "identical points: zero-persistence pair is filtered, 1 essential H0 remains" do
+      # The edge [0,1] has birth = 0.0 (distance is 0), pairing with vertex 1
+      # at death = 0.0. Since birth == death the pair has zero persistence and
+      # is filtered out by compute/2, leaving only one essential H0 class.
+      pts = Nx.tensor([[0.0, 0.0], [0.0, 0.0]])
+      result = Persistence.compute(pts, max_dim: 1)
+      h0_essential = Enum.filter(result.essential, fn {d, _} -> d == 0 end)
+      h0_pairs = Enum.filter(result.pairs, fn {d, _, _} -> d == 0 end)
+      assert length(h0_essential) == 1
+      assert h0_pairs == []
+    end
+
+    test "single-dimensional point cloud has 1 essential H0 and no H1 features" do
+      # Three collinear points form a path graph — no loops possible.
+      pts = Nx.tensor([[0.0], [1.0], [2.0]])
+      result = Persistence.compute(pts, max_dim: 1)
+      h0_essential = Enum.filter(result.essential, fn {d, _} -> d == 0 end)
+      h1_pairs = Enum.filter(result.pairs, fn {d, _, _} -> d == 1 end)
+      assert length(h0_essential) == 1
+      assert h1_pairs == []
+    end
+
+    test "large max_dim does not crash" do
+      # 8 collinear points with max_dim=5 exercises high-dimensional simplex
+      # generation without producing any H1+ topology.
+      pts = Nx.tensor(for i <- 1..8, do: [i * 1.0, 0.0])
+      assert %{pairs: _, essential: _, diagram: _} = Persistence.compute(pts, max_dim: 5)
+    end
   end
 
   describe "Persistence.most_persistent/2" do


### PR DESCRIPTION
## Summary

Adds three new tests to the `Persistence.compute/2` describe block:

- **Identical points** — two points at the same location. Verifies that the zero-persistence H0 pair (birth == death == 0.0) is correctly filtered and exactly one essential H0 class remains. The test was informed by inspecting the actual result, which revealed that `compute/2` intentionally excludes zero-persistence pairs via `birth < death`.
- **Single-dimensional input** — three collinear points `[[0.0], [1.0], [2.0]]`. Verifies 1 essential H0 class and no H1 features (no loops possible on a path graph).
- **Large max_dim** — 8 points with `max_dim: 5`. Verifies high-dimensional simplex generation completes without crashing.

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix test` — 65 tests, 0 failures