### PR TITLE
Add GitHub Actions CI workflow (closes #46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27'
+          elixir-version: '1.18'
+      - run: mix deps.get
+      - run: mix format --check-formatted
+      - run: mix test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` that runs on every push and pull request
- Steps: `deps.get` → `format --check-formatted` → `test`
- EXLA has `runtime: Mix.env() != :test` in `mix.exs`, so tests run on BinaryBackend without needing GPU/CUDA in CI

## Test plan

- [x] Workflow file is valid YAML
- [x] CI run will be triggered by this PR itself — check the Actions tab