### PR TITLE
Enhance module docs with examples and paper reference (closes #47)

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -7,6 +7,16 @@ defmodule PhNx.BoundaryMatrix do
 
   We represent it sparsely as a map `%{col_index => MapSet of row_indices}`.
   Only nonzero columns are stored. Zero columns are absent from the map.
+
+  ## Example
+
+      points = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+      dist = PhNx.Distance.euclidean(points)
+      filtration = PhNx.Filtration.build(dist, 1)
+      {boundary, _} = PhNx.BoundaryMatrix.build(filtration)
+      # Vertices have no boundary (empty columns omitted).
+      # Each edge column holds the indices of its two endpoint vertices:
+      # %{3 => MapSet([0, 1]), 4 => MapSet([0, 2]), 5 => MapSet([1, 2])}
   """
 
   alias PhNx.Filtration

--- a/lib/ph_nx/filtration.ex
+++ b/lib/ph_nx/filtration.ex
@@ -16,6 +16,21 @@ defmodule PhNx.Filtration do
 
   Distance lookups use a flat tuple extracted from the Nx distance matrix, giving
   O(1) access per pair via `elem/2` instead of O(n) nested `Enum.at` traversals.
+
+  ## Example
+
+      points = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+      dist = PhNx.Distance.euclidean(points)
+      filtration = PhNx.Filtration.build(dist, 2)
+      # => [
+      #   %{vertices: [0], dim: 0, birth: 0.0, index: 0},
+      #   %{vertices: [1], dim: 0, birth: 0.0, index: 1},
+      #   %{vertices: [2], dim: 0, birth: 0.0, index: 2},
+      #   %{vertices: [0, 1], dim: 1, birth: 1.0, index: 3},
+      #   %{vertices: [0, 2], dim: 1, birth: 1.0, index: 4},
+      #   %{vertices: [1, 2], dim: 1, birth: 1.414..., index: 5},
+      #   %{vertices: [0, 1, 2], dim: 2, birth: 1.414..., index: 6}
+      # ]
   """
 
   @typedoc "A simplex in the filtration, with its vertex set, dimension, birth time, and index."

--- a/lib/ph_nx/reduction.ex
+++ b/lib/ph_nx/reduction.ex
@@ -14,6 +14,22 @@ defmodule PhNx.Reduction do
 
   Simplices that are never the pivot of any column are "essential": they create
   homology classes that persist to infinity.
+
+  ## Reference
+
+  Edelsbrunner, H., Letscher, D., & Zomorodian, A. (2002).
+  Topological persistence and simplification.
+  *Discrete & Computational Geometry*, 28(4), 511–533.
+
+  ## Example
+
+      points = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+      dist = PhNx.Distance.euclidean(points)
+      filtration = PhNx.Filtration.build(dist, 2)
+      {boundary, _} = PhNx.BoundaryMatrix.build(filtration)
+      %{pairs: pairs, essential: essential} = PhNx.Reduction.reduce(boundary, length(filtration), filtration)
+      # pairs:    [{1, 3}, {2, 4}, {5, 6}]  — birth/death index pairs
+      # essential: [0]                       — vertex 0 generates the lone H0 class
   """
 
   alias PhNx.{BoundaryMatrix, Filtration}


### PR DESCRIPTION
## Summary

- **`PhNx.Filtration`** — adds a usage example showing the full simplex list produced for a right triangle
- **`PhNx.BoundaryMatrix`** — adds a usage example showing the sparse map structure for an edge filtration
- **`PhNx.Reduction`** — adds a usage example showing raw index pairs and essential simplices, plus the Edelsbrunner, Letscher & Zomorodian (2002) citation that the algorithm description already referenced by name

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix test` — 65 tests, 0 failures