### PR TITLE
Add performance characteristics doc and link from README (closes #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ PhNx.most_persistent(result, 5) # => [{dim, birth, death, persistence}, ...]
 
 ## Limitations & future work
 
-- **Scale**: reduction is O(m³) worst-case in the number of simplices. The default threshold (enclosing radius) limits the filtration automatically, but passing `threshold: :infinity` on large point clouds will grow quickly.
+- **Scale**: reduction is O(m³) worst-case in the number of simplices. The default threshold (enclosing radius) limits the filtration automatically, but passing `threshold: :infinity` on large point clouds will grow quickly. See [docs/performance.md](docs/performance.md) for complexity details, benchmark numbers, and guidance on controlling simplex count.
 - **Sparse distance input**: currently only Euclidean point clouds are supported; sparse or precomputed distance matrices could be added.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,51 @@
+# Performance Characteristics
+
+## Complexity by phase
+
+| Phase | Complexity | Notes |
+|---|---|---|
+| Distance matrix | O(n²) | n = number of points; trivially parallelised by EXLA |
+| Filtration construction | O(m) | m = total simplices = Σ C(n,k) for k = 0..max_dim |
+| Boundary matrix | O(m) | Sparse representation; one MapSet per non-vertex simplex |
+| Reduction | O(m³) worst-case | Apparent pairs optimisation reduces this significantly in practice |
+
+The number of simplices m grows as O(nᵈ) where d = max_dim, so the dominant cost shifts from the distance matrix to reduction as n increases.
+
+## Practical limits
+
+| Point cloud size | Recommended setup |
+|---|---|
+| n < 100 | CPU only (BinaryBackend), any max_dim |
+| 100 ≤ n < 1000 | EXLA for distance matrix; reduction is the bottleneck |
+| n ≥ 1000 | Use `threshold` option to limit m; EXLA strongly recommended |
+
+## Benchmark results (reference hardware)
+
+Measured on a 50-point cloud (`test/fixtures/o3_50.txt`, max_dim 2):
+
+| Phase | BinaryBackend | EXLA (CPU) |
+|---|---|---|
+| Distance matrix | ~3 ms | ~0.05 ms (~57× faster) |
+| Filtration | ~1 ms | ~1 ms |
+| Boundary matrix | ~0.5 ms | ~0.5 ms |
+| Reduction | ~18 ms | ~17 ms (~7% faster) |
+
+Reduction dominates (~82% of total time) and is CPU-bound regardless of backend.
+EXLA's benefit is concentrated in the distance matrix phase.
+
+## Controlling simplex count
+
+The `threshold` option is the primary lever for large inputs. The default (enclosing radius) already limits the filtration to the topologically meaningful range:
+
+```elixir
+# Default: threshold = enclosing radius (recommended)
+PhNx.compute(points, max_dim: 2)
+
+# Explicit threshold — ignore simplices born after ε = 1.5
+PhNx.compute(points, max_dim: 2, threshold: 1.5)
+
+# No threshold — include everything (can be very large)
+PhNx.compute(points, max_dim: 2, threshold: :infinity)
+```
+
+To detect Hₖ features you need simplices up to dimension k+1, so keep max_dim as low as your use case allows.

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule PhNx.MixProject do
       homepage_url: "https://github.com/wardjm/ph-nx",
       docs: [
         main: "readme",
-        extras: ["README.md"]
+        extras: ["README.md", "docs/performance.md"]
       ],
       package: [
         licenses: ["MIT"],


### PR DESCRIPTION
## Summary

- Adds `docs/performance.md` with complexity by phase, practical size limits, benchmark numbers, and `threshold`/`max_dim` guidance
- Links it from the README Limitations section rather than inlining the content there
- Registers it in `mix.exs` `extras` so it appears in generated ExDoc

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix test` — 65 tests, 0 failures