### PR TITLE
Add LICENSE section to README (closes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ PhNx.most_persistent(result, 5) # => [{dim, birth, death, persistence}, ...]
 | `PhNx.Reduction` | Standard persistence algorithm (column reduction) |
 | `PhNx.Persistence` | Pairs extraction, barcode formatting |
 
+## License
+
+MIT — see [LICENSE](LICENSE) for details.
+
 ## Limitations & future work
 
 - **Scale**: reduction is O(m³) worst-case in the number of simplices. The default threshold (enclosing radius) limits the filtration automatically, but passing `threshold: :infinity` on large point clouds will grow quickly. See [docs/performance.md](docs/performance.md) for complexity details, benchmark numbers, and guidance on controlling simplex count.


### PR DESCRIPTION
## Summary

Adds a `## License` section linking to the `LICENSE` file, making the MIT license visible to users browsing the repo on GitHub.

## Test plan

- [x] `mix format --check-formatted` passes
- [x] `mix test` — 65 tests, 0 failures