### PR TITLE
Add BoundaryMatrix.reduce_column/2 with internal reduction state

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -101,6 +101,59 @@ defmodule PhNx.BoundaryMatrix do
     end
   end
 
+  @type column_result :: :already_resolved | :zero | :paired
+
+  @doc """
+  Perform one step of the standard column reduction algorithm on column `col`.
+
+  Returns `{result, updated_matrix}` where `result` is one of:
+    * `:already_resolved` — the column was pre-resolved by an apparent pair
+    * `:zero` — the column is (or reduces to) zero; no pair recorded
+    * `:paired` — the column reduced to a nonzero pivot; a pair was recorded
+  """
+  @spec reduce_column(t(), non_neg_integer()) :: {column_result(), t()}
+  def reduce_column(%__MODULE__{ap_resolved: ap_resolved} = bm, col) do
+    if MapSet.member?(ap_resolved, col) do
+      {:already_resolved, bm}
+    else
+      do_reduce_column(bm, col)
+    end
+  end
+
+  defp do_reduce_column(%__MODULE__{columns: cols} = bm, col) do
+    case col_lowest(cols, col) do
+      nil ->
+        {:zero, bm}
+
+      low ->
+        case Map.get(bm.pivot_col, low) do
+          nil ->
+            # No existing pivot — record the pair
+            protected = MapSet.member?(bm.ap_deaths, low)
+
+            new_cols =
+              if protected,
+                do: bm.columns,
+                else: Map.delete(bm.columns, low)
+
+            new_bm = %{
+              bm
+              | columns: new_cols,
+                pivot_col: Map.put(bm.pivot_col, low, col),
+                pairs: [{low, col} | bm.pairs],
+                paired_as_birth: MapSet.put(bm.paired_as_birth, low)
+            }
+
+            {:paired, new_bm}
+
+          pivot_col ->
+            # XOR with the existing pivot column and retry
+            new_cols = xor_columns(bm.columns, col, pivot_col)
+            do_reduce_column(%{bm | columns: new_cols}, col)
+        end
+    end
+  end
+
   # ── Private helpers ────────────────────────────────────────────────────────
 
   defp build_columns(filtration, index_map) do
@@ -151,5 +204,15 @@ defmodule PhNx.BoundaryMatrix do
       nil -> nil
       set -> if MapSet.size(set) == 0, do: nil, else: Enum.max(set)
     end
+  end
+
+  defp xor_columns(columns, dst, src) do
+    col_dst = Map.get(columns, dst, MapSet.new())
+    col_src = Map.get(columns, src, MapSet.new())
+    result = MapSet.symmetric_difference(col_dst, col_src)
+
+    if MapSet.size(result) == 0,
+      do: Map.delete(columns, dst),
+      else: Map.put(columns, dst, result)
   end
 end

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -290,6 +290,66 @@ defmodule PhNxTest do
     end
   end
 
+  # ── BoundaryMatrix.reduce_column/2 ───────────────────────────────────────────
+
+  describe "BoundaryMatrix.reduce_column/2" do
+    # Two-point filtration: [0] idx 0, [1] idx 1, [0,1] idx 2
+    # Bare matrix (no apparent pairs).
+    defp two_point_bare do
+      pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
+      d = Distance.euclidean(pts)
+      f = Filtration.build(d, 1)
+      BoundaryMatrix.from_filtration(f, seed_apparent: false)
+    end
+
+    test ":zero — vertex column (no boundary) returns {:zero, matrix}" do
+      bm = two_point_bare()
+      assert {:zero, _} = BoundaryMatrix.reduce_column(bm, 0)
+    end
+
+    test ":already_resolved — column pre-seeded by apparent pair returns {:already_resolved, matrix}" do
+      # Two-point filtration with apparent pairs seeded: edge [0,1] (idx 2)
+      # forms an apparent pair with vertex [1] (idx 1). So col 2 is in ap_resolved.
+      pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
+      d = Distance.euclidean(pts)
+      f = Filtration.build(d, 1)
+      bm = BoundaryMatrix.from_filtration(f)
+      assert {:already_resolved, _} = BoundaryMatrix.reduce_column(bm, 2)
+    end
+
+    test ":paired — edge column with unique lowest row returns {:paired, matrix}" do
+      # Bare two-point filtration: v0 idx 0, v1 idx 1, e01 idx 2.
+      # Column 2 has boundary {0,1}, lowest=1. No existing pivot at row 1 → paired.
+      bm = two_point_bare()
+      assert {:paired, _} = BoundaryMatrix.reduce_column(bm, 2)
+    end
+
+    test "clearing — birth column is zeroed out after pairing" do
+      # After reducing col 2, its lowest row (1) becomes the pivot.
+      # Clearing lemma: col 1 (the birth) must be deleted → lowest(bm2, 1) == nil.
+      bm = two_point_bare()
+      {:paired, bm2} = BoundaryMatrix.reduce_column(bm, 2)
+      assert BoundaryMatrix.lowest(bm2, 1) == nil
+    end
+
+    test ":paired after XOR — column requiring prior XOR still pairs correctly" do
+      # 4-point square (dim=2), seeded apparent pairs.
+      # v0-v3 idx 0-3, edges idx 4-9, triangles idx 10-13.
+      # Apparent pairs: {1,4},{2,5},{3,6},{9,10},{8,11} → ap_resolved includes 10,11.
+      # Column 12 (t023, boundary={5,7,8}):
+      #   lowest=8, pivot_col[8]=11 → XOR with col11 first, then finds lowest=7 (no pivot) → paired.
+      pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+      d = Distance.euclidean(pts)
+      f = Filtration.build(d, 2)
+      bm = BoundaryMatrix.from_filtration(f)
+      tri023 = Enum.find(f, &(&1.vertices == [0, 2, 3]))
+      assert {:paired, bm2} = BoundaryMatrix.reduce_column(bm, tri023.index)
+      # The birth edge (e23, the one cleared) should now have lowest=nil.
+      e23 = Enum.find(f, &(&1.vertices == [2, 3]))
+      assert BoundaryMatrix.lowest(bm2, e23.index) == nil
+    end
+  end
+
   # ── Reduction ────────────────────────────────────────────────────────────────
 
   describe "Reduction.reduce/1 (with apparent pairs pre-seeded)" do


### PR DESCRIPTION
Closes #63.

## Summary

- Adds `BoundaryMatrix.reduce_column(matrix, col) :: {column_result(), t()}` to the opaque `BoundaryMatrix` struct
- All five bookkeeping sets (`pivot_col`, `pairs`, `ap_resolved`, `ap_deaths`, `paired_as_birth`) are managed inside the struct — callers hold no local reduction state
- Returns `:already_resolved`, `:zero`, or `:paired` with the updated matrix
- The clearing lemma is applied internally (birth column deleted on pairing, unless the column is in `ap_deaths`)

## Test plan

- [x] `:zero` — vertex column (no boundary) returns `{:zero, matrix}`
- [x] `:already_resolved` — column pre-seeded by apparent pair returns `{:already_resolved, matrix}`
- [x] `:paired` — edge column with unique lowest row returns `{:paired, matrix}`
- [x] Clearing — birth column has `lowest == nil` after pairing
- [x] `:paired` after XOR — triangle on 4-point seeded matrix goes through XOR before pairing; correct birth column is cleared