### PR TITLE
Fix 0..(size-1) range bug for empty filtration in reduce/1 and result/1

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -114,7 +114,7 @@ defmodule PhNx.BoundaryMatrix do
   @spec reduce(t()) :: t()
   @spec reduce([Filtration.simplex()]) :: t()
   def reduce(%__MODULE__{size: size} = bm) do
-    Enum.reduce(0..(size - 1), bm, fn col, acc ->
+    Enum.reduce(0..(size - 1)//1, bm, fn col, acc ->
       {_result, acc} = reduce_column(acc, col)
       acc
     end)
@@ -149,7 +149,7 @@ defmodule PhNx.BoundaryMatrix do
     pivot_rows = MapSet.new(Map.keys(bm.pivot_col))
 
     essential =
-      Enum.filter(0..(size - 1), fn i ->
+      Enum.filter(0..(size - 1)//1, fn i ->
         not Map.has_key?(bm.columns, i) and
           not MapSet.member?(pivot_rows, i) and
           not MapSet.member?(bm.paired_as_birth, i) and

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -353,6 +353,14 @@ defmodule PhNxTest do
   # ── BoundaryMatrix.reduce/1 and result/1 ─────────────────────────────────────
 
   describe "BoundaryMatrix.reduce/1 (t())" do
+    test "empty filtration: result/1 returns {[], []}" do
+      {pairs, essential} =
+        BoundaryMatrix.from_filtration([]) |> BoundaryMatrix.reduce() |> BoundaryMatrix.result()
+
+      assert pairs == []
+      assert essential == []
+    end
+
     test "two-point filtration: pairs and essential via result/1" do
       # Filtration: v0(0), v1(1), e01(2). Pair: {1,2}. Essential: [0].
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])


### PR DESCRIPTION
## Summary

- Adds `//1` step to `0..(size-1)` ranges in `reduce/1` (line 117) and `result/1` (line 152) so they produce an empty range when `size` is 0
- Adds a regression test: `BoundaryMatrix.from_filtration([]) |> reduce() |> result()` now returns `{[], []}` instead of `{[], [0, -1]}`
- Eliminates the `Range.new/2` deprecation warning emitted for empty filtrations

Closes #70.

## Test plan

- [x] `mix test` passes (61 tests, 0 failures, no warnings)