### PR TITLE
Move @type column_result to type section at top of BoundaryMatrix

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -30,6 +30,8 @@ defmodule PhNx.BoundaryMatrix do
             ap_deaths: MapSet.t(non_neg_integer())
           }
 
+  @type column_result :: :already_resolved | :zero | :paired
+
   defstruct columns: %{},
             size: 0,
             pivot_col: %{},
@@ -155,8 +157,6 @@ defmodule PhNx.BoundaryMatrix do
 
     {bm.pairs, essential}
   end
-
-  @type column_result :: :already_resolved | :zero | :paired
 
   @doc """
   Perform one step of the standard column reduction algorithm on column `col`.


### PR DESCRIPTION
## Summary
- Moves `@type column_result` from between public functions (after `result/1`, before `reduce_column/2`) to the type section near `@opaque t` at the top of the module.

Closes #73