### PR TITLE
Standardize CLI exit codes and improve error messages

### DIFF
--- a/lib/ph_nx/cli.ex
+++ b/lib/ph_nx/cli.ex
@@ -35,12 +35,20 @@ defmodule PhNx.CLI do
 
     cond do
       invalid != [] ->
-        IO.puts(:stderr, "Unknown option(s): #{Enum.map_join(invalid, ", ", fn {k, _} -> k end)}")
+        IO.puts(
+          :stderr,
+          "Invalid option(s): #{Enum.map_join(invalid, ", ", fn
+            {k, nil} -> k
+            {k, v} -> "#{k}=#{v}"
+          end)}"
+        )
+
         print_usage(:stderr)
         exit({:shutdown, 1})
 
       opts[:help] ->
         print_usage(:stdio)
+        exit({:shutdown, 0})
 
       positional == [] ->
         IO.puts(:stderr, "Error: no input file specified")
@@ -68,9 +76,13 @@ defmodule PhNx.CLI do
         {:ok, pts} ->
           pts
 
-        {:error, reason} ->
+        {:error, :file, reason} ->
           IO.puts(:stderr, "Error reading #{file}: #{reason}")
           exit({:shutdown, 1})
+
+        {:error, :format, reason} ->
+          IO.puts(:stderr, "Error: #{reason}")
+          exit({:shutdown, 2})
       end
 
     compute_opts =
@@ -95,7 +107,7 @@ defmodule PhNx.CLI do
   defp read_points(file) do
     case File.read(file) do
       {:error, reason} ->
-        {:error, :file.format_error(reason)}
+        {:error, :file, :file.format_error(reason)}
 
       {:ok, contents} ->
         lines =
@@ -104,10 +116,10 @@ defmodule PhNx.CLI do
           |> Enum.reject(&(String.trim(&1) == "" or String.starts_with?(String.trim(&1), "#")))
 
         if lines == [] do
-          {:error, "file contains no data points"}
+          {:error, :format, "file contains no data points"}
         else
           case parse_points(lines) do
-            {:error, _} = err -> err
+            {:error, reason} -> {:error, :format, reason}
             points -> {:ok, points}
           end
         end

--- a/test/cli_test.sh
+++ b/test/cli_test.sh
@@ -70,7 +70,7 @@ assert_exit   "no args exits non-zero"       1       mix ph_nx
 assert_stderr "no args prints error"         "no input file" mix ph_nx
 
 assert_exit   "unknown flag exits non-zero"  1       mix ph_nx --bogus
-assert_stderr "unknown flag prints error"    "Unknown option" mix ph_nx --bogus
+assert_stderr "unknown flag prints error"    "Invalid option" mix ph_nx --bogus
 
 assert_exit   "multiple files exits non-zero" 1      mix ph_nx a.txt b.txt
 assert_stderr "multiple files prints error"  "too many" mix ph_nx a.txt b.txt
@@ -79,10 +79,10 @@ assert_stderr "multiple files prints error"  "too many" mix ph_nx a.txt b.txt
 assert_exit   "missing file exits non-zero"  1       mix ph_nx /nonexistent/points.txt
 assert_stderr "missing file prints error"    "Error reading" mix ph_nx /nonexistent/points.txt
 
-assert_exit   "empty file exits non-zero"    1       mix ph_nx "$EMPTY"
+assert_exit   "empty file exits 2"           2       mix ph_nx "$EMPTY"
 assert_stderr "empty file prints friendly error" "no data points" mix ph_nx "$EMPTY"
 
-assert_exit   "invalid coords exits non-zero" 1      mix ph_nx "$INVALID"
+assert_exit   "invalid coords exits 2"       2       mix ph_nx "$INVALID"
 assert_stderr "invalid coords names the line" "line 2" mix ph_nx "$INVALID"
 
 # ── successful runs ─────────────────────────────────────────────────────────

--- a/test/ph_nx_cli_test.exs
+++ b/test/ph_nx_cli_test.exs
@@ -12,7 +12,7 @@ defmodule PhNx.CLITest do
 
   describe "main/1 - argument parsing" do
     test "prints usage to stdout with --help" do
-      output = capture_io(fn -> PhNx.CLI.main(["--help"]) end)
+      output = capture_io(fn -> catch_exit(PhNx.CLI.main(["--help"])) end)
       assert output =~ "Usage:"
       assert output =~ "--max-dim"
     end
@@ -23,7 +23,7 @@ defmodule PhNx.CLITest do
           catch_exit(PhNx.CLI.main(["--unknown"]))
         end)
 
-      assert output =~ "Unknown option"
+      assert output =~ "Invalid option"
     end
 
     test "errors when no file is given" do
@@ -42,6 +42,62 @@ defmodule PhNx.CLITest do
         end)
 
       assert output =~ "too many arguments"
+    end
+  end
+
+  describe "main/1 - exit codes" do
+    test "exits with code 0 for --help" do
+      capture_io(fn ->
+        assert catch_exit(PhNx.CLI.main(["--help"])) == {:shutdown, 0}
+      end)
+    end
+
+    test "exits with code 1 for invalid option" do
+      capture_io(:stderr, fn ->
+        assert catch_exit(PhNx.CLI.main(["--unknown"])) == {:shutdown, 1}
+      end)
+    end
+
+    test "exits with code 1 for option with invalid value type" do
+      capture_io(:stderr, fn ->
+        assert catch_exit(PhNx.CLI.main(["--threshold=abc"])) == {:shutdown, 1}
+      end)
+    end
+
+    test "exits with code 1 when no file given" do
+      capture_io(:stderr, fn ->
+        assert catch_exit(PhNx.CLI.main([])) == {:shutdown, 1}
+      end)
+    end
+
+    test "exits with code 1 when too many files given" do
+      capture_io(:stderr, fn ->
+        assert catch_exit(PhNx.CLI.main(["a.txt", "b.txt"])) == {:shutdown, 1}
+      end)
+    end
+
+    test "exits with code 1 when file does not exist" do
+      capture_io(:stderr, fn ->
+        assert catch_exit(PhNx.CLI.main(["/nonexistent/path/points.txt"])) == {:shutdown, 1}
+      end)
+    end
+
+    test "exits with code 2 on invalid coordinates" do
+      path = tmp_file("0.0,0.0\n1.0,bad\n")
+      on_exit(fn -> File.rm(path) end)
+
+      capture_io(:stderr, fn ->
+        assert catch_exit(PhNx.CLI.main([path])) == {:shutdown, 2}
+      end)
+    end
+
+    test "exits with code 2 when file has no data points" do
+      path = tmp_file("# just a comment\n\n")
+      on_exit(fn -> File.rm(path) end)
+
+      capture_io(:stderr, fn ->
+        assert catch_exit(PhNx.CLI.main([path])) == {:shutdown, 2}
+      end)
     end
   end
 


### PR DESCRIPTION
## Summary

- **Exit code scheme**: 0 = success/help, 1 = usage or file access errors, 2 = data format errors (invalid coordinates, empty file)
- **Error message fix**: `"Unknown option(s)"` → `"Invalid option(s)"` with the bad value included for type mismatches (e.g. `--threshold=abc` now shows `--threshold=abc`, not just `--threshold`)
- **`--help` exit**: now explicitly calls `exit({:shutdown, 0})` for consistency with other branches
- **`read_points/1`**: returns tagged 3-tuples `{:error, :file, reason}` / `{:error, :format, reason}` so `run/2` can map to the right exit code

## Test plan

- [x] 8 new exit-code tests covering all code paths (0, 1, 2)
- [x] Added test for `--threshold=abc` type-mismatch case
- [x] Updated existing `--help` test to use `catch_exit` (required now that it calls `exit/1`)
- [x] Updated "Unknown option" assert to "Invalid option"
- [x] All 18 CLI tests pass: `mix test test/ph_nx_cli_test.exs`