### PR TITLE
Add pairs/1, essential/1, as_tensor/2 accessors to BoundaryMatrix

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -157,49 +157,28 @@ defmodule PhNx.BoundaryMatrix do
         "essential/1 called on an unreduced BoundaryMatrix — call reduce/1 first"
       )
 
-  def essential(%__MODULE__{size: size} = bm) do
-    pivot_rows = MapSet.new(Map.keys(bm.pivot_col))
-
-    Enum.filter(0..(size - 1)//1, fn i ->
-      not Map.has_key?(bm.columns, i) and
-        not MapSet.member?(pivot_rows, i) and
-        not MapSet.member?(bm.ap_resolved, i)
-    end)
-  end
+  def essential(%__MODULE__{} = bm), do: do_essential(bm)
 
   @doc """
   Extract persistence pairs and essential simplex indices from a fully reduced matrix.
 
-  **Must be called after `reduce/1`.** Calling this on an unreduced matrix returns
-  silently incorrect results: only apparent pairs will appear in `pairs`, and
-  `essential` will be heavily overcounted.
+  **Must be called after `reduce/1`.** Raises `ArgumentError` if called on an
+  unreduced matrix.
 
   Returns `{pairs, essential}` where:
     * `pairs` is `[{birth_index, death_index}]` in reverse reduction order — sort if
       stable output is required
     * `essential` is `[simplex_index]` — simplices that create classes persisting to infinity
-
-  The four-condition essential-class filter is applied here and nowhere else.
   """
   @spec result(t()) :: {[{non_neg_integer(), non_neg_integer()}], [non_neg_integer()]}
-  def result(%__MODULE__{size: size} = bm) do
-    # Invariant: keys(pivot_col) = apparent-pair births ∪ reduction-found births.
-    # Apparent pairs seed pivot_col in from_filtration/2; reduction pairs add to pivot_col
-    # in do_reduce_column/2. Both paths land in pivot_col, so a single membership check
-    # here covers all paired births.
-    # ap_resolved additionally excludes apparent-pair death columns, which can remain in
-    # bm.columns when the death index is also a birth in another pair.
-    pivot_rows = MapSet.new(Map.keys(bm.pivot_col))
+  def result(%__MODULE__{reduced: false}),
+    do:
+      raise(
+        ArgumentError,
+        "result/1 called on an unreduced BoundaryMatrix — call reduce/1 first"
+      )
 
-    essential =
-      Enum.filter(0..(size - 1)//1, fn i ->
-        not Map.has_key?(bm.columns, i) and
-          not MapSet.member?(pivot_rows, i) and
-          not MapSet.member?(bm.ap_resolved, i)
-      end)
-
-    {bm.pairs, essential}
-  end
+  def result(%__MODULE__{} = bm), do: {bm.pairs, do_essential(bm)}
 
   @doc """
   Perform one step of the standard column reduction algorithm on column `col`.
@@ -311,5 +290,21 @@ defmodule PhNx.BoundaryMatrix do
     if MapSet.size(result) == 0,
       do: Map.delete(columns, dst),
       else: Map.put(columns, dst, result)
+  end
+
+  # Invariant: keys(pivot_col) = apparent-pair births ∪ reduction-found births.
+  # Apparent pairs seed pivot_col in from_filtration/2; reduction pairs add to pivot_col
+  # in do_reduce_column/2. Both paths land in pivot_col, so a single membership check
+  # here covers all paired births.
+  # ap_resolved additionally excludes apparent-pair death columns, which can remain in
+  # bm.columns when the death index is also a birth in another pair.
+  defp do_essential(%__MODULE__{size: size} = bm) do
+    pivot_rows = MapSet.new(Map.keys(bm.pivot_col))
+
+    Enum.filter(0..(size - 1)//1, fn i ->
+      not Map.has_key?(bm.columns, i) and
+        not MapSet.member?(pivot_rows, i) and
+        not MapSet.member?(bm.ap_resolved, i)
+    end)
   end
 end

--- a/test/edge_cases_test.exs
+++ b/test/edge_cases_test.exs
@@ -154,7 +154,7 @@ defmodule PhNx.EdgeCasesTest do
 
   describe "BoundaryMatrix.result/1 edge cases" do
     test "nil column returns empty result" do
-      bm = BoundaryMatrix.from_filtration([])
+      bm = BoundaryMatrix.from_filtration([]) |> BoundaryMatrix.reduce()
       {pairs, essential} = bm |> BoundaryMatrix.result()
       assert pairs == []
       assert essential == []

--- a/test/error_conditions_test.exs
+++ b/test/error_conditions_test.exs
@@ -149,9 +149,15 @@ defmodule PhNx.ErrorConditionsTest do
   end
 
   describe "BoundaryMatrix.as_tensor/2" do
-    test "empty filtration has size 0 (as_tensor not applicable)" do
-      bm = BoundaryMatrix.from_filtration([])
-      assert bm.size == 0
+    test "produces an all-zero tensor for a vertices-only filtration" do
+      pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
+      d = Distance.euclidean(pts)
+      f = Filtration.build(d, 0)
+      bm = BoundaryMatrix.from_filtration(f)
+      m = length(f)
+      t = BoundaryMatrix.as_tensor(bm, m)
+      assert Nx.shape(t) == {m, m}
+      assert Nx.to_list(t) == [[0, 0], [0, 0]]
     end
   end
 

--- a/test/ph_nx_test.exs
+++ b/test/ph_nx_test.exs
@@ -353,13 +353,13 @@ defmodule PhNxTest do
   # ── BoundaryMatrix.pairs/1 ──────────────────────────────────────────────────
 
   describe "BoundaryMatrix.pairs/1" do
-    test "returns pairs list from a reduced matrix" do
+    test "returns [{birth_idx, death_idx}] from a reduced matrix" do
+      # Two-point filtration: v0(0), v1(1), e01(2). Pair: {1, 2}.
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
       d = Distance.euclidean(pts)
       f = Filtration.build(d, 1)
       bm = f |> BoundaryMatrix.from_filtration(seed_apparent: false) |> BoundaryMatrix.reduce()
-      {expected, _} = BoundaryMatrix.result(bm)
-      assert BoundaryMatrix.pairs(bm) == expected
+      assert {1, 2} in BoundaryMatrix.pairs(bm)
     end
 
     test "raises ArgumentError on an unreduced matrix" do
@@ -374,13 +374,13 @@ defmodule PhNxTest do
   # ── BoundaryMatrix.essential/1 ──────────────────────────────────────────────
 
   describe "BoundaryMatrix.essential/1" do
-    test "returns essential list from a reduced matrix" do
+    test "returns [simplex_idx] of infinite classes from a reduced matrix" do
+      # Two-point filtration: v0(0), v1(1), e01(2). v0 is the lone essential H0.
       pts = Nx.tensor([[0.0, 0.0], [1.0, 0.0]])
       d = Distance.euclidean(pts)
       f = Filtration.build(d, 1)
       bm = f |> BoundaryMatrix.from_filtration(seed_apparent: false) |> BoundaryMatrix.reduce()
-      {_, expected} = BoundaryMatrix.result(bm)
-      assert BoundaryMatrix.essential(bm) == expected
+      assert BoundaryMatrix.essential(bm) == [0]
     end
 
     test "raises ArgumentError on an unreduced matrix" do


### PR DESCRIPTION
Closes #81

## Summary

- Add `pairs/1` and `essential/1` as canonical public accessors on a fully reduced `BoundaryMatrix`; both raise `ArgumentError` if called before `reduce/1` (enforced via a new `reduced: boolean()` struct field set by `reduce/1`)
- Add `result/1` the same guard for consistency — all three now raise on unreduced matrices
- Rename `to_tensor/2` → `as_tensor/2`; remove `to_tensor/2` (no callers outside this repo)
- Extract `do_essential/1` private helper shared by `essential/1` and `result/1` to remove duplication
- Document internal struct fields as implementation details not part of the public API

## Test plan

- [x] `pairs/1` asserts `{1, 2}` in pairs for a known two-point filtration
- [x] `pairs/1` raises `ArgumentError` matching `/unreduced/` on an unreduced matrix
- [x] `essential/1` asserts `[0]` for the lone essential H0 in a two-point filtration
- [x] `essential/1` raises `ArgumentError` matching `/unreduced/` on an unreduced matrix
- [x] `as_tensor/2` describe blocks cover shape, all-zero vertex columns, and edge columns with exactly 2 ones
- [x] All 159 existing tests pass (`mix test`)