### PR TITLE
test: add 2D/3D unit tests for FiltrationBuilder (closes #94)

### DIFF
--- a/test/filtration_builder_test.exs
+++ b/test/filtration_builder_test.exs
@@ -9,7 +9,7 @@ defmodule PhNx.FiltrationBuilderTest do
     [0.0, 1.0]
   ]
 
-  # Tetrahedron: 3 axis-aligned edges (dist=1.0), 3 cross-axis edges (dist=√2≈1.414)
+  # Unit right-angle corner in 3D: 3 axis-aligned edges (dist=1.0), 3 cross-axis edges (dist=√2≈1.414)
   @tet [
     [0.0, 0.0, 0.0],
     [1.0, 0.0, 0.0],
@@ -79,6 +79,16 @@ defmodule PhNx.FiltrationBuilderTest do
     assert Enum.all?(filt, fn s -> s.birth <= 1.0 end)
     # 4 vertices + 3 axis-aligned edges
     assert length(filt) == 7
+
+    surviving_edges = filt |> Enum.filter(&(&1.dim == 1)) |> Enum.map(& &1.vertices)
+    assert surviving_edges == [[0, 1], [0, 2], [0, 3]]
+  end
+
+  test "3D max_dim=2 includes triangles but not tetrahedron" do
+    # C(4,1) + C(4,2) + C(4,3) = 4 + 6 + 4 = 14
+    filt = FiltrationBuilder.build(@tet, max_dim: 2)
+    assert length(filt) == 14
+    assert Enum.all?(filt, fn s -> s.dim <= 2 end)
   end
 
   test "every simplex has required Filtration struct fields" do
@@ -99,10 +109,10 @@ defmodule PhNx.FiltrationBuilderTest do
     assert list_result == tensor_result
   end
 
-  test "3D filtration is sorted by birth time then dimension" do
+  test "3D filtration is sorted by birth time, dimension, then vertices" do
     filt = FiltrationBuilder.build(@tet, max_dim: 3)
-    birth_dim_pairs = Enum.map(filt, fn s -> {s.birth, s.dim} end)
-    assert birth_dim_pairs == Enum.sort(birth_dim_pairs)
+    sort_keys = Enum.map(filt, fn s -> {s.birth, s.dim, s.vertices} end)
+    assert sort_keys == Enum.sort(sort_keys)
   end
 
   test "3D filtration has contiguous 0-based indices" do

--- a/test/filtration_builder_test.exs
+++ b/test/filtration_builder_test.exs
@@ -1,12 +1,20 @@
 defmodule PhNx.FiltrationBuilderTest do
   use ExUnit.Case
 
-  alias PhNx.{FiltrationBuilder, Filtration}
+  alias PhNx.FiltrationBuilder
 
   @tri [
     [0.0, 0.0],
     [1.0, 0.0],
     [0.0, 1.0]
+  ]
+
+  # Tetrahedron: 3 axis-aligned edges (dist=1.0), 3 cross-axis edges (dist=√2≈1.414)
+  @tet [
+    [0.0, 0.0, 0.0],
+    [1.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0],
+    [0.0, 0.0, 1.0]
   ]
 
   test "build full filtration without threshold" do
@@ -40,5 +48,66 @@ defmodule PhNx.FiltrationBuilderTest do
     filt = FiltrationBuilder.build(@tri, max_dim: 1)
     assert length(filt) == 6
     assert Enum.all?(filt, fn s -> s.dim <= 1 end)
+  end
+
+  # 3D point cloud tests
+
+  test "3D tetrahedron builds a filtration with correct simplex count" do
+    # max_dim=3: 4 vertices + 6 edges + 4 triangles + 1 tetrahedron = 15
+    filt = FiltrationBuilder.build(@tet, max_dim: 3)
+    assert length(filt) == 15
+  end
+
+  test "3D max_dim=1 returns only vertices and edges" do
+    # C(4,1) = 4 vertices, C(4,2) = 6 edges
+    filt = FiltrationBuilder.build(@tet, max_dim: 1)
+    assert length(filt) == 10
+    assert Enum.all?(filt, fn s -> s.dim <= 1 end)
+  end
+
+  test "3D max_dim=0 returns only vertices" do
+    filt = FiltrationBuilder.build(@tet, max_dim: 0)
+    assert length(filt) == 4
+    assert Enum.all?(filt, fn s -> s.dim == 0 end)
+    assert Enum.all?(filt, fn s -> s.birth == 0.0 end)
+  end
+
+  test "3D threshold=1.0 keeps only vertices and axis-aligned edges" do
+    # Axis-aligned pairs (dist=1.0): {0,1}, {0,2}, {0,3} — birth ≤ 1.0
+    # Cross-axis pairs (dist=√2≈1.414): {1,2}, {1,3}, {2,3} — birth > 1.0, pruned
+    filt = FiltrationBuilder.build(@tet, max_dim: 3, threshold: 1.0)
+    assert Enum.all?(filt, fn s -> s.birth <= 1.0 end)
+    # 4 vertices + 3 axis-aligned edges
+    assert length(filt) == 7
+  end
+
+  test "every simplex has required Filtration struct fields" do
+    filt = FiltrationBuilder.build(@tet, max_dim: 3)
+
+    for s <- filt do
+      assert is_list(s.vertices), "vertices must be a list"
+      assert is_integer(s.dim) and s.dim >= 0, "dim must be a non-negative integer"
+      assert is_float(s.birth) and s.birth >= 0.0, "birth must be a non-negative float"
+      assert is_integer(s.index) and s.index >= 0, "index must be a non-negative integer"
+      assert length(s.vertices) == s.dim + 1, "vertices count must equal dim + 1"
+    end
+  end
+
+  test "3D Nx.Tensor input produces same filtration as list input" do
+    list_result = FiltrationBuilder.build(@tet, max_dim: 3)
+    tensor_result = FiltrationBuilder.build(Nx.tensor(@tet, type: :f64), max_dim: 3)
+    assert list_result == tensor_result
+  end
+
+  test "3D filtration is sorted by birth time then dimension" do
+    filt = FiltrationBuilder.build(@tet, max_dim: 3)
+    birth_dim_pairs = Enum.map(filt, fn s -> {s.birth, s.dim} end)
+    assert birth_dim_pairs == Enum.sort(birth_dim_pairs)
+  end
+
+  test "3D filtration has contiguous 0-based indices" do
+    filt = FiltrationBuilder.build(@tet, max_dim: 3)
+    indices = Enum.map(filt, fn s -> s.index end)
+    assert indices == Enum.to_list(0..(length(filt) - 1))
   end
 end


### PR DESCRIPTION
## Summary

- Adds 13 tests to `test/filtration_builder_test.exs` covering `PhNx.FiltrationBuilder` for 2D and 3D point clouds
- No implementation changes — pure test addition
- All 208 tests pass

## New 3D test coverage

Using a unit right-angle corner in 3D (`[[0,0,0],[1,0,0],[0,1,0],[0,0,1]]`) with two distinct edge lengths (1.0 and √2≈1.414):

| Test | Behavior verified |
|------|------------------|
| Simplex count at max_dim=3 | 4+6+4+1 = 15 simplices |
| max_dim=0 | Only 4 vertices, all birth=0.0 |
| max_dim=1 | Only vertices + edges (10 total) |
| max_dim=2 | Vertices + edges + triangles (14), no tetrahedron |
| threshold=1.0 | 7 survivors; surviving edges are exactly `[0,1],[0,2],[0,3]` |
| Struct field validation | Every simplex has `vertices`, `dim`, `birth`, `index` with correct types and `len(vertices)==dim+1` |
| Nx.Tensor parity | List and tensor inputs produce identical filtrations |
| Sort order | Filtration sorted by `{birth, dim, vertices}` |
| Index invariant | Indices are contiguous 0-based integers |

## Test plan

- [x] `mix test test/filtration_builder_test.exs` — 13 tests, 0 failures
- [x] `mix test` — 208 tests, 0 failures (no regressions)