### PR TITLE
feat: add PhNx.Topology façade (closes #99)

### DIFF
--- a/lib/ph_nx.ex
+++ b/lib/ph_nx.ex
@@ -17,11 +17,13 @@ defmodule PhNx do
       Distance matrix  →  Vietoris-Rips filtration  →  Boundary matrix  →  Column reduction  →  Persistence pairs
 
   Modules:
-    - `PhNx.Distance`       — Nx-powered pairwise Euclidean distance matrix
-    - `PhNx.Filtration`     — Vietoris-Rips filtration construction
-    - `PhNx.FiltrationBuilder` — convenient wrapper for building filtrations with options
-    - `PhNx.BoundaryMatrix` — sparse boundary matrix over F₂, including column reduction
-    - `PhNx.Persistence`    — high-level API and output formatting
+    - `PhNx.Distance`          — Nx-powered pairwise Euclidean distance matrix
+    - `PhNx.FiltrationBuilder` — Vietoris-Rips filtration with options
+    - `PhNx.Reduction`         — sparse F₂ boundary matrix reduction
+    - `PhNx.Topology`          — façade orchestrating Distance → FiltrationBuilder → Reduction
+    - `PhNx.Filtration`        — low-level filtration construction
+    - `PhNx.BoundaryMatrix`    — sparse boundary matrix over F₂
+    - `PhNx.Persistence`       — output formatting helpers
 
   ## Functions
 
@@ -33,7 +35,7 @@ defmodule PhNx do
   """
 
   @spec compute(Nx.Tensor.t() | [[number()]], keyword()) :: PhNx.Persistence.result()
-  defdelegate compute(points, opts \\ []), to: PhNx.Persistence
+  defdelegate compute(points, opts \\ []), to: PhNx.Topology
 
   @spec print_barcode(PhNx.Persistence.result()) :: :ok
   defdelegate print_barcode(result), to: PhNx.Persistence

--- a/lib/ph_nx/topology.ex
+++ b/lib/ph_nx/topology.ex
@@ -1,0 +1,103 @@
+defmodule PhNx.Topology do
+  @moduledoc """
+  Façade that orchestrates the persistent homology pipeline.
+
+  Delegates to the three deep modules in sequence:
+
+      Distance  →  FiltrationBuilder  →  Reduction  →  Persistence pairs
+
+  Preserves the same `compute/2` signature as `PhNx.Persistence`.
+  """
+
+  alias PhNx.{Distance, FiltrationBuilder, Reduction, BoundaryMatrix}
+
+  @typedoc "Options accepted by `compute/2`."
+  @type options :: [max_dim: non_neg_integer(), threshold: number() | :infinity]
+
+  @doc """
+  Compute persistent homology for a point cloud.
+
+  Options:
+    - `:max_dim` (non-negative integer, default `2`) — maximum simplex dimension.
+    - `:threshold` (non-negative number or `:infinity`, default: enclosing radius) —
+      ignore simplices born after this value.
+    - `:boundary_builder` (`(filtration, opts -> BoundaryMatrix.t())`, default:
+      `&BoundaryMatrix.build_from_filtration/2`) — override the boundary matrix
+      constructor (useful for testing and alternative implementations).
+
+  Returns `%{pairs: [...], essential: [...], diagram: [...]}`.
+  """
+  @spec compute(Nx.Tensor.t() | [[number()]], options()) :: PhNx.Persistence.result()
+  def compute(points, opts \\ []) do
+    opts = Keyword.validate!(opts, [:max_dim, :threshold, :boundary_builder])
+
+    max_dim = Keyword.get(opts, :max_dim, 2)
+
+    unless is_integer(max_dim) and max_dim >= 0 do
+      raise ArgumentError, "max_dim must be a non-negative integer, got: #{inspect(max_dim)}"
+    end
+
+    if points == [] or (is_list(points) and length(points) == 0) do
+      raise ArgumentError, "point cloud must be non-empty"
+    end
+
+    points = if is_list(points), do: Nx.tensor(points, type: :f64), else: points
+
+    if Nx.axis_size(points, 0) == 0 do
+      raise ArgumentError, "point cloud must be non-empty"
+    end
+
+    dist = Distance.euclidean(points)
+
+    threshold =
+      case Keyword.fetch(opts, :threshold) do
+        {:ok, t} -> t
+        :error -> Distance.enclosing_radius(dist)
+      end
+
+    unless threshold == :infinity or (is_number(threshold) and threshold >= 0) do
+      raise ArgumentError,
+            "threshold must be :infinity or a non-negative number, got: #{inspect(threshold)}"
+    end
+
+    filtration = FiltrationBuilder.build(points, max_dim: max_dim, threshold: threshold)
+
+    builder = Keyword.get(opts, :boundary_builder, &BoundaryMatrix.build_from_filtration/2)
+
+    unless is_function(builder, 2) do
+      raise ArgumentError,
+            "boundary_builder must be a 2-arity function, got: #{inspect(builder)}"
+    end
+
+    builder_opts = opts |> Keyword.delete(:boundary_builder) |> Keyword.delete(:threshold)
+    reduced = builder.(filtration, builder_opts) |> BoundaryMatrix.reduce()
+    raw_pairs = BoundaryMatrix.pairs(reduced)
+    raw_essential = BoundaryMatrix.essential(reduced)
+
+    idx_to_simplex = Map.new(filtration, fn s -> {s.index, s} end)
+
+    pairs =
+      raw_pairs
+      |> Enum.map(fn {i, j} ->
+        s_i = Map.fetch!(idx_to_simplex, i)
+        s_j = Map.fetch!(idx_to_simplex, j)
+        {s_i.dim, s_i.birth, s_j.birth}
+      end)
+      |> Enum.filter(fn {_dim, birth, death} -> birth < death end)
+      |> Enum.sort()
+
+    essential =
+      raw_essential
+      |> Enum.map(fn i ->
+        s = Map.fetch!(idx_to_simplex, i)
+        {s.dim, s.birth}
+      end)
+      |> Enum.sort()
+
+    diagram =
+      (pairs ++ Enum.map(essential, fn {d, b} -> {d, b, :infinity} end))
+      |> Enum.sort()
+
+    %{pairs: pairs, essential: essential, diagram: diagram}
+  end
+end

--- a/lib/ph_nx/topology.ex
+++ b/lib/ph_nx/topology.ex
@@ -12,7 +12,11 @@ defmodule PhNx.Topology do
   alias PhNx.{Distance, FiltrationBuilder, Reduction, BoundaryMatrix}
 
   @typedoc "Options accepted by `compute/2`."
-  @type options :: [max_dim: non_neg_integer(), threshold: number() | :infinity]
+  @type options :: [
+          max_dim: non_neg_integer(),
+          threshold: number() | :infinity,
+          boundary_builder: (list(), keyword() -> BoundaryMatrix.t())
+        ]
 
   @doc """
   Compute persistent homology for a point cloud.
@@ -37,7 +41,7 @@ defmodule PhNx.Topology do
       raise ArgumentError, "max_dim must be a non-negative integer, got: #{inspect(max_dim)}"
     end
 
-    if points == [] or (is_list(points) and length(points) == 0) do
+    if points == [] do
       raise ArgumentError, "point cloud must be non-empty"
     end
 
@@ -69,8 +73,8 @@ defmodule PhNx.Topology do
             "boundary_builder must be a 2-arity function, got: #{inspect(builder)}"
     end
 
-    builder_opts = opts |> Keyword.delete(:boundary_builder) |> Keyword.delete(:threshold)
-    reduced = builder.(filtration, builder_opts) |> BoundaryMatrix.reduce()
+    builder_opts = Keyword.delete(opts, :boundary_builder)
+    reduced = builder.(filtration, builder_opts) |> Reduction.reduce()
     raw_pairs = BoundaryMatrix.pairs(reduced)
     raw_essential = BoundaryMatrix.essential(reduced)
 

--- a/test/topology_test.exs
+++ b/test/topology_test.exs
@@ -1,0 +1,95 @@
+defmodule PhNx.TopologyTest do
+  use ExUnit.Case, async: true
+
+  # Four corners of a unit square — H0: 1 component, H1: 1 loop
+  @square Nx.tensor([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]])
+
+  describe "PhNx.Topology.compute/2" do
+    test "returns result map with pairs, essential, and diagram keys" do
+      result = PhNx.Topology.compute(@square)
+      assert is_map(result)
+      assert Map.has_key?(result, :pairs)
+      assert Map.has_key?(result, :essential)
+      assert Map.has_key?(result, :diagram)
+    end
+
+    test "detects correct topology for unit square (H0: 1 component, H1: 1 loop)" do
+      result = PhNx.Topology.compute(@square)
+
+      # H0: 1 essential class (1 connected component that persists forever)
+      h0_essential = Enum.filter(result.essential, fn {d, _} -> d == 0 end)
+      assert length(h0_essential) == 1
+
+      # H1: 1 finite pair (the loop)
+      h1_pairs = Enum.filter(result.pairs, fn {d, _, _} -> d == 1 end)
+      assert length(h1_pairs) == 1
+    end
+
+    test "matches Persistence.compute/2 output for the same input" do
+      result_topology = PhNx.Topology.compute(@square)
+      result_persistence = PhNx.Persistence.compute(@square)
+
+      assert result_topology.pairs == result_persistence.pairs
+      assert result_topology.essential == result_persistence.essential
+      assert result_topology.diagram == result_persistence.diagram
+    end
+
+    test "respects :max_dim option" do
+      result_dim1 = PhNx.Topology.compute(@square, max_dim: 1)
+      result_dim2 = PhNx.Topology.compute(@square, max_dim: 2)
+
+      # With max_dim: 1 there are no triangles to kill the H1 loop, so it
+      # shows up as an essential class (infinite bar) rather than a finite pair.
+      h1_essential_dim1 = Enum.filter(result_dim1.essential, fn {d, _} -> d == 1 end)
+      assert length(h1_essential_dim1) >= 1
+
+      # With max_dim: 2 triangles fill in the loop, producing a finite H1 pair.
+      h1_pairs_dim2 = Enum.filter(result_dim2.pairs, fn {d, _, _} -> d == 1 end)
+      assert length(h1_pairs_dim2) == 1
+    end
+
+    test "respects :threshold option" do
+      # With a tiny threshold, only the closest points are included
+      result = PhNx.Topology.compute(@square, threshold: 0.5)
+      # At threshold 0.5, no edges of the unit square (length 1.0) are included
+      # so we get 4 isolated components
+      h0_essential = Enum.filter(result.essential, fn {d, _} -> d == 0 end)
+      assert length(h0_essential) == 4
+    end
+
+    test "raises ArgumentError for empty point cloud" do
+      assert_raise ArgumentError, fn ->
+        PhNx.Topology.compute([])
+      end
+    end
+
+    test "raises ArgumentError for invalid :max_dim" do
+      assert_raise ArgumentError, fn ->
+        PhNx.Topology.compute(@square, max_dim: -1)
+      end
+    end
+
+    test "raises ArgumentError for invalid :threshold" do
+      assert_raise ArgumentError, fn ->
+        PhNx.Topology.compute(@square, threshold: -1.0)
+      end
+    end
+  end
+
+  describe "PhNx.compute/2 public API" do
+    test "still works and returns correct result (no breaking change)" do
+      result = PhNx.compute(@square)
+      assert Map.has_key?(result, :pairs)
+      assert Map.has_key?(result, :essential)
+      assert Map.has_key?(result, :diagram)
+    end
+
+    test "matches Topology.compute/2 output" do
+      result_facade = PhNx.compute(@square)
+      result_topology = PhNx.Topology.compute(@square)
+
+      assert result_facade.pairs == result_topology.pairs
+      assert result_facade.essential == result_topology.essential
+    end
+  end
+end

--- a/test/topology_test.exs
+++ b/test/topology_test.exs
@@ -74,6 +74,23 @@ defmodule PhNx.TopologyTest do
         PhNx.Topology.compute(@square, threshold: -1.0)
       end
     end
+
+    test "accepts custom :boundary_builder and passes opts through" do
+      test_pid = self()
+
+      custom_builder = fn filtration, opts ->
+        send(test_pid, {:builder_called, length(filtration), opts})
+        PhNx.BoundaryMatrix.build_from_filtration(filtration, opts)
+      end
+
+      result = PhNx.Topology.compute(@square, boundary_builder: custom_builder)
+
+      assert_received {:builder_called, _, received_opts}
+      refute Keyword.has_key?(received_opts, :boundary_builder)
+      assert Map.has_key?(result, :pairs)
+      assert Map.has_key?(result, :essential)
+      assert Map.has_key?(result, :diagram)
+    end
   end
 
   describe "PhNx.compute/2 public API" do
@@ -90,6 +107,7 @@ defmodule PhNx.TopologyTest do
 
       assert result_facade.pairs == result_topology.pairs
       assert result_facade.essential == result_topology.essential
+      assert result_facade.diagram == result_topology.diagram
     end
   end
 end


### PR DESCRIPTION
## Summary

- Introduces `PhNx.Topology` module that orchestrates `Distance → FiltrationBuilder → Reduction` in sequence
- `PhNx.compute/2` now delegates to `PhNx.Topology` instead of `PhNx.Persistence` — no breaking changes to the public API
- Supports all existing options including `:max_dim`, `:threshold`, and `:boundary_builder` (preserving test-injection capability used in the ripser comparison tests)

## Test plan

- [x] 10 new tests in `test/topology_test.exs` covering result structure, correct topology detection (unit square H0/H1), option handling, parity with `Persistence.compute/2`, and error cases
- [x] All 240 existing tests continue to pass
- [x] `mix format` applied