### PR TITLE
test: add --threshold CLI integration test (closes #102)

### DIFF
--- a/test/ph_nx_cli_test.exs
+++ b/test/ph_nx_cli_test.exs
@@ -179,5 +179,19 @@ defmodule PhNx.CLITest do
       File.rm(path)
       assert output =~ "Computing"
     end
+
+    test "respects --threshold option" do
+      path =
+        tmp_file("0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n")
+
+      output =
+        capture_io(fn ->
+          PhNx.CLI.main([path, "--threshold", "0.5"])
+        end)
+
+      File.rm(path)
+      assert output =~ "Computing persistent homology for 4 points in 2D"
+      assert output =~ "Betti numbers"
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Issue #102 was already satisfied by the topology-facade work in PR #122: the CLI calls `PhNx.compute/2` which delegates to `PhNx.Topology` and the deep modules
- Adds a missing `--threshold` integration test to `test/ph_nx_cli_test.exs` to explicitly verify the flag is accepted and produces valid output

## Test plan

- [x] `mix test test/ph_nx_cli_test.exs` — all 19 tests pass