### PR TITLE
feat: add on_progress callback to Reduction.reduce/2 (closes #105)

### DIFF
--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -186,8 +186,8 @@ defmodule PhNx.BoundaryMatrix do
     %{result | reduced: true}
   end
 
-  def reduce(filtration, _opts) when is_list(filtration) do
-    filtration |> build_from_filtration() |> reduce()
+  def reduce(filtration, opts) when is_list(filtration) do
+    filtration |> build_from_filtration() |> reduce(opts)
   end
 
   @doc """

--- a/lib/ph_nx/boundary_matrix.ex
+++ b/lib/ph_nx/boundary_matrix.ex
@@ -156,10 +156,16 @@ defmodule PhNx.BoundaryMatrix do
   default `build_from_filtration/2` options (apparent pairs seeded).
   """
   @spec reduce(t()) :: t()
+  @spec reduce(t(), keyword()) :: t()
   @spec reduce([Filtration.simplex()]) :: t()
-  def reduce(%__MODULE__{coeff_ring: :z2, size: size} = bm) do
+  def reduce(bm_or_filtration, opts \\ [])
+
+  def reduce(%__MODULE__{coeff_ring: :z2, size: size} = bm, opts) do
+    on_progress = Keyword.get(opts, :on_progress)
+
     result =
       Enum.reduce(0..(size - 1)//1, bm, fn col, acc ->
+        if on_progress, do: on_progress.(%{current: col, total: size})
         {_result, acc} = reduce_column(acc, col)
         acc
       end)
@@ -167,9 +173,12 @@ defmodule PhNx.BoundaryMatrix do
     %{result | reduced: true}
   end
 
-  def reduce(%__MODULE__{coeff_ring: {:zp, p}, size: size} = bm) do
+  def reduce(%__MODULE__{coeff_ring: {:zp, p}, size: size} = bm, opts) do
+    on_progress = Keyword.get(opts, :on_progress)
+
     result =
       Enum.reduce(0..(size - 1)//1, bm, fn col, acc ->
+        if on_progress, do: on_progress.(%{current: col, total: size})
         {_result, acc} = do_reduce_zp_column(acc, col, p)
         acc
       end)
@@ -177,7 +186,7 @@ defmodule PhNx.BoundaryMatrix do
     %{result | reduced: true}
   end
 
-  def reduce(filtration) when is_list(filtration) do
+  def reduce(filtration, _opts) when is_list(filtration) do
     filtration |> build_from_filtration() |> reduce()
   end
 

--- a/lib/ph_nx/reduction.ex
+++ b/lib/ph_nx/reduction.ex
@@ -21,14 +21,16 @@ defmodule PhNx.Reduction do
           BoundaryMatrix.t()
   def reduce(input, opts \\ [])
 
-  def reduce(%BoundaryMatrix{} = bm, _opts) do
-    BoundaryMatrix.reduce(bm)
+  def reduce(%BoundaryMatrix{} = bm, opts) do
+    BoundaryMatrix.reduce(bm, opts)
   end
 
   def reduce(filtration, opts) when is_list(filtration) do
+    {progress_opts, build_opts} = Keyword.split(opts, [:on_progress])
+
     filtration
-    |> BoundaryMatrix.build_from_filtration(opts)
-    |> BoundaryMatrix.reduce()
+    |> BoundaryMatrix.build_from_filtration(build_opts)
+    |> BoundaryMatrix.reduce(progress_opts)
   end
 
   def reduce(other, _opts) do

--- a/lib/ph_nx/reduction.ex
+++ b/lib/ph_nx/reduction.ex
@@ -16,6 +16,13 @@ defmodule PhNx.Reduction do
   from the filtration and then performs the reduction.
 
   Returns the reduced boundary matrix.
+
+  ## Options
+
+  - `:on_progress` — a 1-arity callback invoked once per column during reduction.
+    Receives `%{current: non_neg_integer(), total: pos_integer()}`.
+  - `:coeff` — coefficient ring; `{:zp, p}` for ℤₚ arithmetic (default: ℤ₂).
+  - `:seed_apparent` — when `true`, seeds apparent pairs before reduction (default: `false`).
   """
   @spec reduce(BoundaryMatrix.t() | list(PhNx.Filtration.simplex()), keyword()) ::
           BoundaryMatrix.t()

--- a/test/reduction_test.exs
+++ b/test/reduction_test.exs
@@ -132,5 +132,14 @@ defmodule PhNx.ReductionTest do
 
       assert_received :progress
     end
+
+    test "BoundaryMatrix.reduce/2 filtration overload forwards opts" do
+      filtration = PhNx.Filtration.build(@points, 1)
+      me = self()
+
+      BoundaryMatrix.reduce(filtration, on_progress: fn p -> send(me, {:progress, p}) end)
+
+      assert_received {:progress, _}
+    end
   end
 end

--- a/test/reduction_test.exs
+++ b/test/reduction_test.exs
@@ -90,4 +90,47 @@ defmodule PhNx.ReductionTest do
       assert reduced_bm.pairs != []
     end
   end
+
+  describe "on_progress callback" do
+    test "is invoked at least once during reduction" do
+      filtration = PhNx.Filtration.build(@points, 1)
+      me = self()
+
+      Reduction.reduce(filtration, on_progress: fn _p -> send(me, :progress) end)
+
+      assert_received :progress
+    end
+
+    test "is called once per column with correct current and total" do
+      filtration = PhNx.Filtration.build(@points, 1)
+      me = self()
+
+      Reduction.reduce(filtration, on_progress: fn p -> send(me, {:progress, p}) end)
+
+      calls =
+        Stream.repeatedly(fn ->
+          receive do
+            {:progress, p} -> p
+          after
+            0 -> nil
+          end
+        end)
+        |> Enum.take_while(&(&1 != nil))
+
+      size = length(filtration)
+      assert length(calls) == size
+      assert Enum.map(calls, & &1.current) == Enum.to_list(0..(size - 1))
+      assert Enum.all?(calls, &(&1.total == size))
+    end
+
+    test "works with a BoundaryMatrix input" do
+      filtration = PhNx.Filtration.build(@points, 1)
+      bm = BoundaryMatrix.build_from_filtration(filtration)
+      me = self()
+
+      Reduction.reduce(bm, on_progress: fn _p -> send(me, :progress) end)
+
+      assert_received :progress
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Reduction.reduce/2` now accepts `on_progress: fn %{current: col, total: size} -> ... end`
- Callback fires once per column in the reduction loop for both ℤ₂ and ℤₚ rings
- `BoundaryMatrix.reduce/2` gained an opts overload to carry the callback into the inner loop
- Build opts (`seed_apparent:`, `coeff:`) are cleanly split from progress opts in `Reduction`
- Zero overhead when callback is absent (`if nil` short-circuits in the hot loop)

## Test plan

- [ ] `on_progress` callback is invoked at least once during reduction
- [ ] Callback fires exactly once per column, with `current` 0..size-1 and correct `total`
- [ ] Works with both `BoundaryMatrix` and filtration list inputs
- [ ] All 261 existing tests continue to pass (no regressions)

Closes #105