### PR TITLE
feat: streaming point cloud input via compute_stream/2 and --stream flag (closes #106)

### DIFF
--- a/lib/ph_nx.ex
+++ b/lib/ph_nx.ex
@@ -48,6 +48,12 @@ defmodule PhNx do
           %{optional(non_neg_integer()) => non_neg_integer()}
   defdelegate betti_numbers(result), to: PhNx.Persistence
 
+  @spec compute_stream(Enumerable.t()) :: PhNx.Persistence.result()
+  defdelegate compute_stream(points), to: PhNx.Persistence
+
+  @spec compute_stream(Enumerable.t(), keyword()) :: PhNx.Persistence.result()
+  defdelegate compute_stream(points, opts), to: PhNx.Persistence
+
   @spec filtration_builder(Nx.Tensor.t() | [[number()]]) :: [PhNx.Filtration.simplex()]
   defdelegate filtration_builder(points), to: PhNx.FiltrationBuilder, as: :build
 

--- a/lib/ph_nx.ex
+++ b/lib/ph_nx.ex
@@ -28,6 +28,7 @@ defmodule PhNx do
   ## Functions
 
     - `compute/1`, `compute/2`     — compute persistent homology of a point cloud
+    - `compute_stream/1`, `compute_stream/2` — stream-based persistent homology of a point cloud
     - `print_barcode/1`            — print the barcode visualization
     - `most_persistent/1`, `most_persistent/2` — get the most persistent features
     - `betti_numbers/1`            — get Betti numbers for each dimension

--- a/lib/ph_nx/cli.ex
+++ b/lib/ph_nx/cli.ex
@@ -58,6 +58,11 @@ defmodule PhNx.CLI do
         print_usage(:stdio)
         exit({:shutdown, 0})
 
+      opts[:stream] && positional != [] ->
+        IO.puts(:stderr, "Error: --stream and a file argument cannot be combined")
+        print_usage(:stderr)
+        exit({:shutdown, 1})
+
       opts[:stream] ->
         run_stream(opts)
 
@@ -104,15 +109,7 @@ defmodule PhNx.CLI do
     IO.puts("Computing persistent homology for #{length(points)} points in #{dim(points)}D...")
 
     result = PhNx.compute(points, compute_opts)
-    PhNx.print_barcode(result)
-
-    betti = PhNx.betti_numbers(result)
-
-    IO.puts("\nBetti numbers:")
-
-    Enum.each(betti, fn {d, count} ->
-      IO.puts("  β#{d} = #{count}")
-    end)
+    print_results(result)
   end
 
   defp run_stream(opts) do
@@ -126,6 +123,10 @@ defmodule PhNx.CLI do
     IO.puts("Computing persistent homology for #{length(points)} points in #{dim(points)}D...")
 
     result = PhNx.compute_stream(points, compute_opts)
+    print_results(result)
+  end
+
+  defp print_results(result) do
     PhNx.print_barcode(result)
 
     betti = PhNx.betti_numbers(result)
@@ -142,9 +143,15 @@ defmodule PhNx.CLI do
       Stream.unfold(:ok, fn
         :ok ->
           case IO.read(:stdio, :line) do
-            :eof -> nil
-            :error -> nil
-            line -> {String.trim(line), :ok}
+            :eof ->
+              nil
+
+            {:error, reason} ->
+              IO.puts(:stderr, "Error reading stdin: #{inspect(reason)}")
+              exit({:shutdown, 2})
+
+            line ->
+              {String.trim(line), :ok}
           end
       end)
       |> Enum.filter(&(String.trim(&1) != "" and not String.starts_with?(String.trim(&1), "#")))

--- a/lib/ph_nx/cli.ex
+++ b/lib/ph_nx/cli.ex
@@ -5,6 +5,7 @@ defmodule PhNx.CLI do
   ## Usage
 
       ph_nx <file> [options]
+      ph_nx --stream [options]
 
   The file should contain one point per line, with coordinates comma-separated:
 
@@ -15,10 +16,17 @@ defmodule PhNx.CLI do
 
   Points can be in any dimension as long as all points have the same number of coordinates.
 
+  When using `--stream`, points are read from stdin instead of a file. This enables
+  piping data from other commands:
+
+      cat points.csv | ph_nx --stream
+      curl -s https://example.com/points.csv | ph_nx --stream
+
   ## Options
 
       --max-dim N     Maximum homology dimension to compute (default: 2)
       --threshold T   Distance threshold for filtration (default: enclosing radius)
+      --stream        Read points from stdin instead of a file
       --help          Show this help message
 
   ## Building the escript
@@ -30,7 +38,7 @@ defmodule PhNx.CLI do
   def main(args) do
     {opts, positional, invalid} =
       OptionParser.parse(args,
-        strict: [max_dim: :integer, threshold: :float, help: :boolean]
+        strict: [max_dim: :integer, threshold: :float, help: :boolean, stream: :boolean]
       )
 
     cond do
@@ -49,6 +57,9 @@ defmodule PhNx.CLI do
       opts[:help] ->
         print_usage(:stdio)
         exit({:shutdown, 0})
+
+      opts[:stream] ->
+        run_stream(opts)
 
       positional == [] ->
         IO.puts(:stderr, "Error: no input file specified")
@@ -102,6 +113,55 @@ defmodule PhNx.CLI do
     Enum.each(betti, fn {d, count} ->
       IO.puts("  β#{d} = #{count}")
     end)
+  end
+
+  defp run_stream(opts) do
+    points = read_stream_points()
+
+    compute_opts =
+      []
+      |> maybe_put(:max_dim, opts[:max_dim])
+      |> maybe_put(:threshold, opts[:threshold])
+
+    IO.puts("Computing persistent homology for #{length(points)} points in #{dim(points)}D...")
+
+    result = PhNx.compute_stream(points, compute_opts)
+    PhNx.print_barcode(result)
+
+    betti = PhNx.betti_numbers(result)
+
+    IO.puts("\nBetti numbers:")
+
+    Enum.each(betti, fn {d, count} ->
+      IO.puts("  β#{d} = #{count}")
+    end)
+  end
+
+  defp read_stream_points() do
+    lines =
+      Stream.unfold(:ok, fn
+        :ok ->
+          case IO.read(:stdio, :line) do
+            :eof -> nil
+            :error -> nil
+            line -> {String.trim(line), :ok}
+          end
+      end)
+      |> Enum.filter(&(String.trim(&1) != "" and not String.starts_with?(String.trim(&1), "#")))
+
+    if lines == [] do
+      IO.puts(:stderr, "Error: no data points received on stdin")
+      exit({:shutdown, 2})
+    end
+
+    case parse_points(lines) do
+      {:error, reason} ->
+        IO.puts(:stderr, "Error: #{reason}")
+        exit({:shutdown, 2})
+
+      points ->
+        points
+    end
   end
 
   defp read_points(file) do
@@ -158,9 +218,10 @@ defmodule PhNx.CLI do
   defp print_usage(device) do
     IO.puts(device, """
     Usage: ph_nx <file> [options]
+           ph_nx --stream [options]
 
-    Compute persistent homology from a point cloud file.
-    Each line in the file should be a comma-separated list of coordinates:
+    Compute persistent homology from a point cloud file or stdin stream.
+    Each line in the input should be a comma-separated list of coordinates:
 
         0.0,0.0
         1.0,0.0
@@ -170,6 +231,7 @@ defmodule PhNx.CLI do
     Options:
       --max-dim N     Maximum homology dimension to compute (default: 2)
       --threshold T   Distance threshold for filtration (default: enclosing radius)
+      --stream        Read points from stdin instead of a file
       --help          Show this help message
     """)
   end

--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -145,13 +145,26 @@ defmodule PhNx.Persistence do
   @doc """
   Compute persistent homology for a point cloud, using lazy filtration streaming.
 
-  This function accepts an `Enumerable.t()` of points (e.g. a stream from `IO.stream/2`
-  or a lazy collection), making it suitable for processing large or remote datasets
-  without loading all points into memory before computation begins.
+  This function accepts an `Enumerable.t()` of points — a plain list, a `Stream`, or any
+  other lazy collection — so callers that already have points behind an enumerable
+  (file-backed iterators, `IO.stream/2`, resource streams) can pass it directly instead
+  of collecting it themselves first.
 
-  The distance matrix is still materialised (it requires all points), but the Vietoris-Rips
-  filtration is built lazily via `FiltrationBuilder.stream/2`, keeping peak memory usage
-  lower than the batch `compute/2` for very large point clouds.
+  ## Performance
+
+  This is a convenience over `compute/2`, not an optimisation. It is currently **slower
+  than `compute/2` and uses comparable memory**; prefer `compute/2` when you already hold
+  a list or tensor.
+
+  The enumerable is fully materialised before computation: the distance matrix requires
+  all points, and although the Vietoris-Rips filtration is generated via
+  `FiltrationBuilder.stream/2`, it is then sorted globally, which realises it in full.
+  Measured on 55 points (`max_dim: 2, threshold: :infinity`), peak memory was 45.4 MB
+  versus 48.1 MB for `compute/2` — within noise — while wall-clock was 1.4-2x slower,
+  because `FiltrationBuilder.stream/2` reads birth times out of the distance tensor
+  per vertex pair rather than from a flat tuple.
+
+  Results are numerically identical to `compute/2` for the same options.
 
   ## Options
 
@@ -159,24 +172,30 @@ defmodule PhNx.Persistence do
     - `:max_dim` (default `2`)
     - `:threshold` (default: enclosing radius)
     - `:boundary_builder` (default: `&BoundaryMatrix.build_from_filtration/2`)
+    - `:coeff` — coefficient ring; `{:zp, p}` for ℤₚ arithmetic (default: ℤ₂)
+    - `:on_progress` — 1-arity callback invoked once per column during reduction
+
+  Note that `:backend` is accepted by `PhNx.Topology.compute/2` but not here.
 
   ## Examples
 
-      iex> stream = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
-      iex> result = PhNx.Persistence.compute_stream(stream)
-      iex> is_map(result) and Map.has_key?(result, :pairs)
+      iex> points = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
+      iex> result = PhNx.Persistence.compute_stream(Stream.map(points, & &1), max_dim: 1)
+      iex> result == PhNx.compute(points, max_dim: 1)
       true
   """
   @spec compute_stream(Enumerable.t(), keyword()) :: result()
   def compute_stream(points_stream, opts \\ []) do
-    opts = Keyword.validate!(opts, [:max_dim, :threshold, :boundary_builder])
+    opts =
+      Keyword.validate!(opts, [:max_dim, :threshold, :boundary_builder, :coeff, :on_progress])
+
     max_dim = Keyword.get(opts, :max_dim, 2)
 
     if not is_integer(max_dim) or max_dim < 0 do
       raise ArgumentError, "max_dim must be a non-negative integer, got: #{inspect(max_dim)}"
     end
 
-    # Materialise the enumerable into a list so we can inspect it
+    # The distance matrix needs every point, so the enumerable is realised in full here.
     points_list = Enum.to_list(points_stream)
 
     if points_list == [] do

--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -15,7 +15,7 @@ defmodule PhNx.Persistence do
       PhNx.Persistence.print_barcode(result)
   """
 
-  alias PhNx.{Distance, Filtration, BoundaryMatrix}
+  alias PhNx.{Distance, Filtration, BoundaryMatrix, Reduction}
 
   @typedoc "A finite persistence pair: {dimension, birth, death}."
   @type pair :: {non_neg_integer(), float(), float()}
@@ -162,7 +162,7 @@ defmodule PhNx.Persistence do
 
   ## Examples
 
-      iex> stream = Stream.iterate([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], & &1)
+      iex> stream = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
       iex> result = PhNx.Persistence.compute_stream(stream)
       iex> is_map(result) and Map.has_key?(result, :pairs)
       true
@@ -184,10 +184,6 @@ defmodule PhNx.Persistence do
     end
 
     points = Nx.tensor(points_list, type: :f64)
-
-    if Nx.axis_size(points, 0) == 0 do
-      raise ArgumentError, "point cloud must be non-empty"
-    end
 
     dist = Distance.euclidean(points)
 
@@ -217,7 +213,7 @@ defmodule PhNx.Persistence do
       |> Enum.with_index()
       |> Enum.map(fn {simplex, idx} -> Map.put(simplex, :index, idx) end)
 
-    reduced = builder.(filtration, builder_opts) |> BoundaryMatrix.reduce()
+    reduced = builder.(filtration, builder_opts) |> Reduction.reduce(builder_opts)
     raw_pairs = BoundaryMatrix.pairs(reduced)
     raw_essential = BoundaryMatrix.essential(reduced)
 

--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -143,6 +143,115 @@ defmodule PhNx.Persistence do
   end
 
   @doc """
+  Compute persistent homology for a point cloud, using lazy filtration streaming.
+
+  This function accepts an `Enumerable.t()` of points (e.g. a stream from `IO.stream/2`
+  or a lazy collection), making it suitable for processing large or remote datasets
+  without loading all points into memory before computation begins.
+
+  The distance matrix is still materialised (it requires all points), but the Vietoris-Rips
+  filtration is built lazily via `FiltrationBuilder.stream/2`, keeping peak memory usage
+  lower than the batch `compute/2` for very large point clouds.
+
+  ## Options
+
+  Same as `compute/2`:
+    - `:max_dim` (default `2`)
+    - `:threshold` (default: enclosing radius)
+    - `:boundary_builder` (default: `&BoundaryMatrix.build_from_filtration/2`)
+
+  ## Examples
+
+      iex> stream = Stream.iterate([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], & &1)
+      iex> result = PhNx.Persistence.compute_stream(stream)
+      iex> is_map(result) and Map.has_key?(result, :pairs)
+      true
+  """
+  @spec compute_stream(Enumerable.t(), keyword()) :: result()
+  def compute_stream(points_stream, opts \\ []) do
+    opts = Keyword.validate!(opts, [:max_dim, :threshold, :boundary_builder])
+    max_dim = Keyword.get(opts, :max_dim, 2)
+
+    if not is_integer(max_dim) or max_dim < 0 do
+      raise ArgumentError, "max_dim must be a non-negative integer, got: #{inspect(max_dim)}"
+    end
+
+    # Materialise the enumerable into a list so we can inspect it
+    points_list = Enum.to_list(points_stream)
+
+    if points_list == [] do
+      raise ArgumentError, "point cloud must be non-empty"
+    end
+
+    points = Nx.tensor(points_list, type: :f64)
+
+    if Nx.axis_size(points, 0) == 0 do
+      raise ArgumentError, "point cloud must be non-empty"
+    end
+
+    dist = Distance.euclidean(points)
+
+    threshold =
+      Keyword.get_lazy(opts, :threshold, fn -> Distance.enclosing_radius(dist) end)
+
+    unless threshold == :infinity or (is_number(threshold) and threshold >= 0) do
+      raise ArgumentError,
+            "threshold must be :infinity or a non-negative number, got: #{inspect(threshold)}"
+    end
+
+    builder = Keyword.get(opts, :boundary_builder, &BoundaryMatrix.build_from_filtration/2)
+
+    unless is_function(builder, 2) do
+      raise ArgumentError, "boundary_builder must be a 2-arity function, got: #{inspect(builder)}"
+    end
+
+    builder_opts = Keyword.delete(opts, :boundary_builder)
+
+    # Use FiltrationBuilder.stream/2 for lazy filtration generation, then sort
+    # globally (like build/2 does) and add :index fields so the result is
+    # compatible with BoundaryMatrix.build_from_filtration/2
+    filtration =
+      points
+      |> PhNx.FiltrationBuilder.stream(max_dim: max_dim, threshold: threshold)
+      |> Enum.sort_by(fn %{birth: b, dim: d, vertices: v} -> {b, d, v} end)
+      |> Enum.with_index()
+      |> Enum.map(fn {simplex, idx} -> Map.put(simplex, :index, idx) end)
+
+    reduced = builder.(filtration, builder_opts) |> BoundaryMatrix.reduce()
+    raw_pairs = BoundaryMatrix.pairs(reduced)
+    raw_essential = BoundaryMatrix.essential(reduced)
+
+    # Map filtration indices back to (dim, birth) info
+    idx_to_simplex = Map.new(filtration, fn s -> {s.index, s} end)
+
+    pairs =
+      raw_pairs
+      |> Enum.map(fn {i, j} ->
+        s_i = Map.fetch!(idx_to_simplex, i)
+        s_j = Map.fetch!(idx_to_simplex, j)
+        # The homology class lives in dimension = dim of the creator (lower dim simplex)
+        dim = s_i.dim
+        {dim, s_i.birth, s_j.birth}
+      end)
+      |> Enum.filter(fn {_dim, birth, death} -> birth < death end)
+      |> Enum.sort()
+
+    essential =
+      raw_essential
+      |> Enum.map(fn i ->
+        s = Map.fetch!(idx_to_simplex, i)
+        {s.dim, s.birth}
+      end)
+      |> Enum.sort()
+
+    diagram =
+      (pairs ++ Enum.map(essential, fn {d, b} -> {d, b, :infinity} end))
+      |> Enum.sort()
+
+    %{pairs: pairs, essential: essential, diagram: diagram}
+  end
+
+  @doc """
   Print a human-readable barcode summary.
   """
   @spec print_barcode(result()) :: :ok

--- a/test/persistence_test.exs
+++ b/test/persistence_test.exs
@@ -37,4 +37,91 @@ defmodule PhNx.PersistenceTest do
       end
     end
   end
+
+  describe "Persistence.compute_stream/2" do
+    test "produces same result as compute/2 for a point cloud" do
+      points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+      batch_result = Persistence.compute(points)
+      stream_result = Persistence.compute_stream(points)
+
+      assert batch_result == stream_result
+    end
+
+    test "accepts an empty stream and raises ArgumentError" do
+      assert_raise ArgumentError, ~r/point cloud must be non-empty/, fn ->
+        Persistence.compute_stream([])
+      end
+    end
+
+    test "accepts options: max_dim" do
+      points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+      result = Persistence.compute_stream(points, max_dim: 1)
+
+      assert is_map(result)
+      assert Map.has_key?(result, :pairs)
+      assert Map.has_key?(result, :essential)
+      assert Map.has_key?(result, :diagram)
+    end
+
+    test "accepts options: threshold" do
+      points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+      result = Persistence.compute_stream(points, threshold: 0.5)
+
+      assert is_map(result)
+      assert Map.has_key?(result, :pairs)
+    end
+
+    test "accepts options: boundary_builder" do
+      points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]
+      test_pid = self()
+
+      custom_builder = fn filtration, opts ->
+        send(test_pid, :stream_builder_called)
+        BoundaryMatrix.build_from_filtration(filtration, opts)
+      end
+
+      Persistence.compute_stream(points, boundary_builder: custom_builder)
+
+      assert_received :stream_builder_called
+    end
+
+    test "raises ArgumentError for invalid max_dim" do
+      assert_raise ArgumentError, ~r/max_dim must be a non-negative integer/, fn ->
+        Persistence.compute_stream([[0.0, 0.0]], max_dim: -1)
+      end
+    end
+
+    test "raises ArgumentError for invalid threshold" do
+      assert_raise ArgumentError, ~r/threshold must be :infinity or a non-negative number/, fn ->
+        Persistence.compute_stream([[0.0, 0.0]], threshold: -1.0)
+      end
+    end
+
+    test "raises ArgumentError when boundary_builder is not a function" do
+      assert_raise ArgumentError, ~r/boundary_builder must be a 2-arity function/, fn ->
+        Persistence.compute_stream([[0.0, 0.0]], boundary_builder: :not_a_function)
+      end
+    end
+
+    test "works with 1D points" do
+      points = [[0.0], [1.0], [2.0], [3.0]]
+
+      result = Persistence.compute_stream(points)
+
+      assert is_map(result)
+      assert Map.has_key?(result, :diagram)
+    end
+
+    test "works with 3D points" do
+      points = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+
+      result = Persistence.compute_stream(points)
+
+      assert is_map(result)
+      assert Map.has_key?(result, :diagram)
+    end
+  end
 end

--- a/test/persistence_test.exs
+++ b/test/persistence_test.exs
@@ -54,24 +54,52 @@ defmodule PhNx.PersistenceTest do
       end
     end
 
+    test "accepts a lazy enumerable, not just a list" do
+      points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+      lazy = Stream.map(points, & &1)
+
+      assert Persistence.compute_stream(lazy) == PhNx.compute(points)
+    end
+
     test "accepts options: max_dim" do
       points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
 
       result = Persistence.compute_stream(points, max_dim: 1)
 
-      assert is_map(result)
-      assert Map.has_key?(result, :pairs)
-      assert Map.has_key?(result, :essential)
-      assert Map.has_key?(result, :diagram)
+      assert result == PhNx.compute(points, max_dim: 1)
+      refute result == Persistence.compute_stream(points, max_dim: 2)
     end
 
     test "accepts options: threshold" do
       points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
 
-      result = Persistence.compute_stream(points, threshold: 0.5)
+      assert Persistence.compute_stream(points, threshold: 0.5) ==
+               PhNx.compute(points, threshold: 0.5)
+
+      assert Persistence.compute_stream(points, threshold: :infinity) ==
+               PhNx.compute(points, threshold: :infinity)
+    end
+
+    test "honours :on_progress during reduction" do
+      points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+      test_pid = self()
+
+      Persistence.compute_stream(points,
+        on_progress: fn progress -> send(test_pid, {:progress, progress}) end
+      )
+
+      assert_received {:progress, %{current: _, total: total}}
+      assert total > 0
+    end
+
+    test "honours :coeff for Zp arithmetic" do
+      points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+      result = Persistence.compute_stream(points, coeff: {:zp, 3})
 
       assert is_map(result)
-      assert Map.has_key?(result, :pairs)
+      assert Map.has_key?(result, :diagram)
     end
 
     test "accepts options: boundary_builder" do

--- a/test/persistence_test.exs
+++ b/test/persistence_test.exs
@@ -39,10 +39,10 @@ defmodule PhNx.PersistenceTest do
   end
 
   describe "Persistence.compute_stream/2" do
-    test "produces same result as compute/2 for a point cloud" do
+    test "produces same result as PhNx.compute/2 for a point cloud" do
       points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
 
-      batch_result = Persistence.compute(points)
+      batch_result = PhNx.compute(points)
       stream_result = Persistence.compute_stream(points)
 
       assert batch_result == stream_result

--- a/test/ph_nx_cli_test.exs
+++ b/test/ph_nx_cli_test.exs
@@ -15,6 +15,7 @@ defmodule PhNx.CLITest do
       output = capture_io(fn -> catch_exit(PhNx.CLI.main(["--help"])) end)
       assert output =~ "Usage:"
       assert output =~ "--max-dim"
+      assert output =~ "--stream"
     end
 
     test "errors on unknown option" do
@@ -190,6 +191,66 @@ defmodule PhNx.CLITest do
         end)
 
       File.rm(path)
+      assert output =~ "Computing persistent homology for 4 points in 2D"
+      assert output =~ "Betti numbers"
+    end
+  end
+
+  describe "main/1 - streaming mode (--stream)" do
+    test "reads points from stdin when --stream is given" do
+      input = "0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n"
+
+      output =
+        capture_io(input, fn ->
+          PhNx.CLI.main(["--stream"])
+        end)
+
+      assert output =~ "Computing persistent homology for 4 points in 2D"
+      assert output =~ "Betti numbers"
+    end
+
+    test "skips comments and blank lines in stream" do
+      input = "# header\n\n0.0,0.0\n\n1.0,0.0\n1.0,1.0\n# footer\n0.0,1.0\n"
+
+      output =
+        capture_io(input, fn ->
+          PhNx.CLI.main(["--stream"])
+        end)
+
+      assert output =~ "4 points in 2D"
+    end
+
+    test "errors on empty stdin" do
+      capture_io("", fn ->
+        assert catch_exit(PhNx.CLI.main(["--stream"])) == {:shutdown, 2}
+      end)
+    end
+
+    test "errors on invalid coordinates in stream" do
+      capture_io("0.0,0.0\n1.0,bad\n", fn ->
+        assert catch_exit(PhNx.CLI.main(["--stream"])) == {:shutdown, 2}
+      end)
+    end
+
+    test "respects --max-dim in stream mode" do
+      input = "0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n"
+
+      output =
+        capture_io(input, fn ->
+          PhNx.CLI.main(["--stream", "--max-dim", "1"])
+        end)
+
+      assert output =~ "Computing"
+    end
+
+    test "respects --threshold in stream mode" do
+      input = "0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n"
+
+      output =
+        capture_io(input, fn ->
+          PhNx.CLI.main(["--stream", "--threshold", "0.5"])
+        end)
+
       assert output =~ "Computing persistent homology for 4 points in 2D"
       assert output =~ "Betti numbers"
     end

--- a/test/ph_nx_cli_test.exs
+++ b/test/ph_nx_cli_test.exs
@@ -197,6 +197,16 @@ defmodule PhNx.CLITest do
   end
 
   describe "main/1 - streaming mode (--stream)" do
+    test "rejects --stream combined with a file argument" do
+      output =
+        capture_io(:stderr, fn ->
+          assert catch_exit(PhNx.CLI.main(["points.csv", "--stream"])) == {:shutdown, 1}
+        end)
+
+      assert output =~ "--stream and a file argument cannot be combined"
+      assert output =~ "Usage:"
+    end
+
     test "reads points from stdin when --stream is given" do
       input = "0.0,0.0\n1.0,0.0\n1.0,1.0\n0.0,1.0\n"
 


### PR DESCRIPTION
## Summary

- Adds `PhNx.compute_stream/2` (and `PhNx.Persistence.compute_stream/2`) accepting any `Enumerable.t()` of points — streams, lazy collections, file-backed iterators — so callers holding points behind an enumerable can pass it directly instead of collecting it first
- Adds `--stream` CLI flag to read points from stdin (`cat points.csv | ph_nx --stream`)
- Existing batch `compute/2` API is unchanged; all 282 tests pass

## Performance: this is a convenience, not an optimisation

An earlier revision of this PR claimed lower peak memory. **That claim was wrong and has been removed.** Measured on 55 points (`max_dim: 2, threshold: :infinity`):

| | `compute/2` | `compute_stream/2` |
|---|---|---|
| Peak memory | 48.1 MB | 45.4 MB (within noise) |
| Wall clock | 1.0x | 1.4–2x slower |

The enumerable is fully materialised (the distance matrix needs all points), and the filtration — though generated via `FiltrationBuilder.stream/2` — is then sorted globally, realising it in full. The slowdown comes from `FiltrationBuilder.stream/2` reading birth times out of the distance tensor per vertex pair rather than from a flat tuple.

Prefer `compute/2` when you already hold a list or tensor. Results are numerically identical between the two paths.

## Changes

**API (`lib/ph_nx/persistence.ex`, `lib/ph_nx.ex`)**
- `compute_stream/2` materialises the enumerable, builds the distance matrix, generates the Vietoris-Rips filtration via `FiltrationBuilder.stream/2`, then sorts, indexes and reduces
- `compute_stream/1,2` delegated from the top-level `PhNx` module
- Accepts `:max_dim`, `:threshold`, `:boundary_builder`, plus `:coeff` and `:on_progress`, which route through `Reduction.reduce/2`. Note `:backend` is accepted by `Topology.compute/2` but not here.

**CLI (`lib/ph_nx/cli.ex`)**
- `--stream` flag enters `run_stream/1`, reading points line-by-line from stdin
- Rejects `--stream` combined with a positional file argument with a clear error
- Distinguishes `{:error, reason}` from `:eof` in the stdin reader
- Shared barcode+Betti output extracted into `print_results/1`
- Note: the CLI materialises stdin fully before computing, so it does not yet benefit from the streaming API

## Known follow-ups (not addressed here)

- `compute_stream/2` lives in `Persistence` while `compute/2` delegates to `Topology`; the streaming variant arguably belongs alongside its sibling, with `:backend` support for symmetry
- The distance matrix is computed twice (once for `enclosing_radius`, once inside `stream/2`)
- The result-extraction tail is now duplicated a third time (also in `persistence.ex` `compute/2` and `topology.ex`)
- Threading the precomputed `dist` into `FiltrationBuilder.stream/2` would close most of the wall-clock gap

## Test plan

- [x] `mix test` passes (282 tests, 0 failures)
- [x] `echo "0,0\n1,0\n0,1\n1,1" | ph_nx --stream` produces expected barcode
- [x] `ph_nx myfile.csv --stream` prints the conflict error and exits 1 (now covered by a test)
- [x] `ph_nx myfile.csv` (file path) still works as before — byte-identical output to the stream path
- [x] `:on_progress` and `:coeff` verified to reach the reduction

Note: the built escript cannot load the EXLA NIF on Linux (`libexla.so: cannot open shared object file`), so CLI items were verified under `MIX_ENV=test` (`Nx.BinaryBackend`). This is pre-existing and affects plain file mode on `main` identically — worth a separate issue for escript packaging.

Closes #106
