### PR TITLE
fix(cli): make the built escript runnable (closes #130)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,6 @@ jobs:
       - run: mix format --check-formatted
       - run: mix test
       - run: bash test/cli_test.sh
+      # Builds the escript and runs it end to end. The escript is the
+      # distribution artifact and is not exercised by mix test (issue #130).
+      - run: bash test/escript_test.sh

--- a/README.md
+++ b/README.md
@@ -133,6 +133,32 @@ Betti numbers:
 
 Points can be in any dimension as long as all points in the file have the same number of coordinates. The `--max-dim` and `--threshold` options correspond directly to the options for `PhNx.compute/2`.
 
+Points can also be streamed on stdin with `--stream`:
+
+```
+$ cat square.txt | ph_nx --stream
+```
+
+### Standalone escript
+
+```
+$ mix escript.build
+$ ./ph_nx square.txt
+```
+
+The escript is a single self-contained file that needs only an Erlang runtime on the target machine.
+
+### Backends used by the CLI
+
+| Entry point | Backend |
+|---|---|
+| `mix ph_nx` (dev) | `EXLA.Backend`, falling back to `Nx.BinaryBackend` with a warning on stderr if EXLA cannot be loaded |
+| `./ph_nx` (escript) | `Nx.BinaryBackend` |
+
+`mix escript.build` builds with `MIX_ENV=prod`, where EXLA is neither configured nor bundled, so the escript computes on `Nx.BinaryBackend`. An escript is a single archive: the `priv/` directory of `:exla` is never unpacked to disk and its NIF (`libexla.so`) cannot be loaded, so accelerated backends and escripts are mutually exclusive. (Forcing a build with `MIX_ENV=dev` still runs — the CLI detects that EXLA is unusable and falls back with a warning — but gains nothing.)
+
+Results are identical either way; only speed differs. Use `mix ph_nx` or the library API with EXLA configured when acceleration matters.
+
 ## License
 
 MIT — see [LICENSE](LICENSE) for details.

--- a/lib/mix/tasks/ph_nx.ex
+++ b/lib/mix/tasks/ph_nx.ex
@@ -25,7 +25,11 @@ defmodule Mix.Tasks.PhNx do
 
   @impl Mix.Task
   def run(args) do
-    Mix.Task.run("app.start")
+    # --no-start so a broken accelerator install cannot abort the task before
+    # the CLI runs; PhNx.Backend starts the backend itself once it has checked
+    # that it is usable, and reports a fallback instead of crashing.
+    Mix.Task.run("app.start", ["--no-start"])
+    Application.ensure_all_started(:nx)
     PhNx.CLI.main(args)
   end
 end

--- a/lib/ph_nx/backend.ex
+++ b/lib/ph_nx/backend.ex
@@ -1,0 +1,99 @@
+defmodule PhNx.Backend do
+  @moduledoc """
+  Chooses the `Nx` backend the CLI computes with.
+
+  The library itself never selects a backend — that is the host application's
+  job. The CLI is the host application for `mix ph_nx` and for the escript, so
+  it has to make the choice, and it has to make it without crashing when an
+  accelerated backend cannot be loaded.
+
+  Two situations matter:
+
+    * The escript. An escript is a single archive, so the `priv/` directory of
+      a backend like `:exla` is never written to disk and `libexla.so` can
+      never be `dlopen`ed. The escript is built with `MIX_ENV=prod`, where no
+      accelerated backend is configured or even bundled, so it runs on
+      `Nx.BinaryBackend`.
+
+    * A development checkout on a machine without working XLA binaries. Here
+      `config/dev.exs` asks for `EXLA.Backend` and starting `:exla` fails.
+      Rather than let that surface as an Erlang crash report, fall back to
+      `Nx.BinaryBackend` and say so on stderr.
+
+  `select/2` decides; `install/1` applies the decision. They are separate so
+  the decision can be tested without mutating global backend state.
+  """
+
+  @typedoc "A backend as `Nx` accepts it: a module, or a module with options."
+  @type backend :: module() | {module(), keyword()}
+
+  @typedoc """
+  `{:ok, backend}` when the configured backend is usable, `{:fallback,
+  backend, reason}` when it is not and `reason` explains the substitution.
+  """
+  @type decision :: {:ok, backend()} | {:fallback, backend(), String.t()}
+
+  @doc """
+  Decides which backend to use.
+
+  `configured` is the backend the application environment asks for (`nil` when
+  nothing is configured); `usable?` is the probe that reports whether a given
+  backend can actually be loaded and started. Both are injectable for testing.
+  """
+  @spec select(backend() | nil, (backend() -> boolean())) :: decision()
+  def select(configured \\ Application.get_env(:nx, :default_backend), usable? \\ &usable?/1) do
+    cond do
+      binary_backend?(configured) ->
+        {:ok, Nx.BinaryBackend}
+
+      usable?.(configured) ->
+        {:ok, configured}
+
+      true ->
+        {:fallback, Nx.BinaryBackend,
+         "#{inspect(module(configured))} is configured but could not be loaded; " <>
+           "falling back to Nx.BinaryBackend (correct results, but slower). " <>
+           "See the Backends section of the README."}
+    end
+  end
+
+  @doc """
+  Installs the backend from a `select/2` decision and returns the decision
+  unchanged, so callers can report a fallback to the user.
+  """
+  @spec install(decision()) :: decision()
+  def install(decision) do
+    backend = elem(decision, 1)
+
+    # Nx.global_default_backend/1 reads the current value first, which needs
+    # :nx to be loaded. The escript starts no applications, so load it here.
+    Application.ensure_loaded(:nx)
+    Nx.global_default_backend(backend)
+    decision
+  end
+
+  defp binary_backend?(nil), do: true
+  defp binary_backend?(backend), do: module(backend) == Nx.BinaryBackend
+
+  defp module({mod, _opts}), do: mod
+  defp module(mod), do: mod
+
+  # A backend module lives in the application named after its first segment:
+  # EXLA.Backend -> :exla, Torchx.Backend -> :torchx. Starting it is the real
+  # test — EXLA loads fine as a module and only fails when its NIF is missing,
+  # which raises rather than returning an error tuple.
+  defp usable?(configured) do
+    mod = module(configured)
+
+    Code.ensure_loaded?(mod) and
+      match?({:ok, _}, Application.ensure_all_started(backend_app(mod)))
+  rescue
+    _ -> false
+  catch
+    :exit, _ -> false
+  end
+
+  defp backend_app(mod) do
+    mod |> Module.split() |> hd() |> Macro.underscore() |> String.to_atom()
+  end
+end

--- a/lib/ph_nx/cli.ex
+++ b/lib/ph_nx/cli.ex
@@ -101,29 +101,32 @@ defmodule PhNx.CLI do
           exit({:shutdown, 2})
       end
 
-    compute_opts =
-      []
-      |> maybe_put(:max_dim, opts[:max_dim])
-      |> maybe_put(:threshold, opts[:threshold])
-
-    IO.puts("Computing persistent homology for #{length(points)} points in #{dim(points)}D...")
-
-    result = PhNx.compute(points, compute_opts)
-    print_results(result)
+    compute_and_print(points, opts, &PhNx.compute/2)
   end
 
   defp run_stream(opts) do
-    points = read_stream_points()
+    read_stream_points()
+    |> compute_and_print(opts, &PhNx.compute_stream/2)
+  end
 
+  defp compute_and_print(points, opts, compute) do
     compute_opts =
       []
       |> maybe_put(:max_dim, opts[:max_dim])
       |> maybe_put(:threshold, opts[:threshold])
 
+    # Selecting the backend is deferred until we are about to compute, so that
+    # --help and argument errors never depend on a backend being loadable.
+    case PhNx.Backend.install(PhNx.Backend.select()) do
+      {:fallback, _backend, reason} -> IO.puts(:stderr, "Warning: #{reason}")
+      {:ok, _backend} -> :ok
+    end
+
     IO.puts("Computing persistent homology for #{length(points)} points in #{dim(points)}D...")
 
-    result = PhNx.compute_stream(points, compute_opts)
-    print_results(result)
+    points
+    |> compute.(compute_opts)
+    |> print_results()
   end
 
   defp print_results(result) do

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,10 @@ defmodule PhNx.MixProject do
       description: "Persistent homology computation for Elixir using Nx",
       source_url: "https://github.com/wardjm/ph-nx",
       homepage_url: "https://github.com/wardjm/ph-nx",
-      escript: [main_module: PhNx.CLI],
+      # app: nil so the escript starts no applications of its own. Starting
+      # :exla from inside an archive raises a NIF load error before main/1 is
+      # ever reached; the CLI picks its backend explicitly instead.
+      escript: [main_module: PhNx.CLI, app: nil],
       docs: [
         main: "readme",
         extras: ["README.md", "docs/performance.md"]
@@ -23,6 +26,13 @@ defmodule PhNx.MixProject do
     ]
   end
 
+  # Build the escript in :prod. An escript is a single archive, so the priv/
+  # directory of :exla is never on disk and its NIF cannot be loaded; :prod is
+  # the environment that does not configure EXLA as the default backend.
+  def cli do
+    [preferred_envs: ["escript.build": :prod]]
+  end
+
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
@@ -34,7 +44,10 @@ defmodule PhNx.MixProject do
   defp deps do
     [
       {:nx, "~> 0.9"},
-      {:exla, "~> 0.11.0", runtime: Mix.env() != :test},
+      # EXLA is an optional accelerator (see the README): consumers add it
+      # themselves. Keeping it out of :prod also keeps it out of the escript,
+      # which cannot load its NIF from inside the archive.
+      {:exla, "~> 0.11.0", only: [:dev, :test], runtime: Mix.env() != :test},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false}
     ]
   end

--- a/test/backend_test.exs
+++ b/test/backend_test.exs
@@ -1,0 +1,67 @@
+defmodule PhNx.BackendTest do
+  # install/1 sets the global default backend, so this suite cannot run
+  # concurrently with suites that compute tensors.
+  use ExUnit.Case, async: false
+
+  alias PhNx.Backend
+
+  defp available, do: fn _backend -> true end
+  defp unavailable, do: fn _backend -> false end
+
+  describe "select/2 when no accelerated backend is configured" do
+    test "uses the binary backend without probing" do
+      probe = fn _ -> flunk("an unaccelerated backend should not be probed") end
+
+      assert {:ok, Nx.BinaryBackend} = Backend.select(nil, probe)
+      assert {:ok, Nx.BinaryBackend} = Backend.select(Nx.BinaryBackend, probe)
+      assert {:ok, Nx.BinaryBackend} = Backend.select({Nx.BinaryBackend, []}, probe)
+    end
+  end
+
+  describe "select/2 when an accelerated backend is configured" do
+    test "keeps the configured backend when it is usable" do
+      assert {:ok, EXLA.Backend} = Backend.select(EXLA.Backend, available())
+
+      assert {:ok, {EXLA.Backend, [client: :host]}} =
+               Backend.select({EXLA.Backend, [client: :host]}, available())
+    end
+
+    test "probes the configured backend, not a hardcoded one" do
+      probe = fn backend -> send(self(), {:probed, backend}) && true end
+
+      Backend.select(Torchx.Backend, probe)
+      assert_received {:probed, Torchx.Backend}
+    end
+
+    test "falls back to the binary backend when it is not usable" do
+      assert {:fallback, Nx.BinaryBackend, reason} = Backend.select(EXLA.Backend, unavailable())
+      assert reason =~ "EXLA.Backend"
+      assert reason =~ "Nx.BinaryBackend"
+    end
+
+    test "names the configured backend in the fallback reason" do
+      assert {:fallback, Nx.BinaryBackend, reason} =
+               Backend.select({Torchx.Backend, [device: :cuda]}, unavailable())
+
+      assert reason =~ "Torchx.Backend"
+    end
+  end
+
+  describe "install/1" do
+    setup do
+      previous = Application.get_env(:nx, :default_backend)
+      on_exit(fn -> Application.put_env(:nx, :default_backend, previous) end)
+      :ok
+    end
+
+    test "installs the selected backend and returns the decision unchanged" do
+      assert {:ok, Nx.BinaryBackend} = Backend.install({:ok, Nx.BinaryBackend})
+      assert {Nx.BinaryBackend, []} = Application.get_env(:nx, :default_backend)
+
+      assert {:fallback, Nx.BinaryBackend, "boom"} =
+               Backend.install({:fallback, Nx.BinaryBackend, "boom"})
+
+      assert {Nx.BinaryBackend, []} = Application.get_env(:nx, :default_backend)
+    end
+  end
+end

--- a/test/cli_test.sh
+++ b/test/cli_test.sh
@@ -5,36 +5,8 @@ set -euo pipefail
 
 export MIX_ENV=test
 
-PASS=0
-FAIL=0
-
-pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
-fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
-
-assert_exit() {
-  local desc="$1" expected="$2"
-  shift 2
-  local actual
-  actual=0
-  "$@" >/dev/null 2>&1 || actual=$?
-  if [ "$actual" -eq "$expected" ]; then pass "$desc"; else fail "$desc (expected exit $expected, got $actual)"; fi
-}
-
-assert_stdout() {
-  local desc="$1" pattern="$2"
-  shift 2
-  local out
-  out=$("$@" 2>/dev/null)
-  if echo "$out" | grep -q "$pattern"; then pass "$desc"; else fail "$desc (pattern '$pattern' not found in output)"; fi
-}
-
-assert_stderr() {
-  local desc="$1" pattern="$2"
-  shift 2
-  local err
-  err=$("$@" 2>&1 >/dev/null || true)
-  if echo "$err" | grep -q "$pattern"; then pass "$desc"; else fail "$desc (pattern '$pattern' not found in stderr)"; fi
-}
+# shellcheck source=test/support/sh_assert.sh
+source "$(dirname "$0")/support/sh_assert.sh"
 
 TMPDIR_CUSTOM=$(mktemp -d)
 cleanup() { rm -rf "$TMPDIR_CUSTOM"; }
@@ -97,6 +69,4 @@ assert_exit   "--max-dim option accepted"     0       mix ph_nx "$SQUARE" --max-
 assert_exit   "--threshold option accepted"   0       mix ph_nx "$SQUARE" --threshold 5.0
 
 # ── summary ─────────────────────────────────────────────────────────────────
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-[ "$FAIL" -eq 0 ]
+summary

--- a/test/escript_test.sh
+++ b/test/escript_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# End-to-end tests for the built escript.
+#
+# Unlike test/cli_test.sh (which runs the mix task in-process), this builds the
+# distribution artifact with `mix escript.build` and executes it. That is the
+# only way to catch packaging failures — an escript cannot carry the EXLA NIF,
+# so a runtime-started :exla makes every invocation fail (issue #130).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# shellcheck source=test/support/sh_assert.sh
+source "test/support/sh_assert.sh"
+
+TMPDIR_CUSTOM=$(mktemp -d)
+cleanup() { rm -rf "$TMPDIR_CUSTOM"; }
+trap cleanup EXIT
+
+SQUARE="$TMPDIR_CUSTOM/square.txt"
+cat > "$SQUARE" <<'EOF'
+0.0,0.0
+1.0,0.0
+1.0,1.0
+0.0,1.0
+EOF
+
+EMPTY="$TMPDIR_CUSTOM/empty.txt"
+printf '# only comments\n\n' > "$EMPTY"
+
+# ── build ───────────────────────────────────────────────────────────────────
+mix escript.build >/dev/null
+ESCRIPT="./ph_nx"
+[ -x "$ESCRIPT" ] || { echo "FAIL: escript was not built"; exit 1; }
+
+# ── packaging ───────────────────────────────────────────────────────────────
+# The escript must not bundle a NIF-backed backend: its priv/ directory is
+# never unpacked, so the NIF could not be loaded even if it were shipped.
+if grep -qa "Elixir.EXLA" "$ESCRIPT"; then
+  fail "escript bundles no EXLA beams"
+else
+  pass "escript bundles no EXLA beams"
+fi
+
+# ── startup ─────────────────────────────────────────────────────────────────
+# These fail on a machine without XLA libraries if :exla is started by the
+# escript, regardless of the arguments given.
+assert_exit      "--help exits 0"                  0        "$ESCRIPT" --help
+assert_stdout    "--help prints Usage"             "Usage"  "$ESCRIPT" --help
+assert_no_stderr "--help writes nothing to stderr"          "$ESCRIPT" --help
+
+# ── file mode ───────────────────────────────────────────────────────────────
+assert_exit      "file mode exits 0"                0             "$ESCRIPT" "$SQUARE"
+assert_stdout    "file mode prints point count"     "4 points"    "$ESCRIPT" "$SQUARE"
+assert_stdout    "file mode prints H0 bars"         "H0 (4 bars)" "$ESCRIPT" "$SQUARE"
+assert_stdout    "file mode prints H1 bar"          "H1 (1 bar)"  "$ESCRIPT" "$SQUARE"
+assert_stdout    "file mode prints Betti numbers"   "β0 = 1"      "$ESCRIPT" "$SQUARE"
+assert_no_stderr "file mode writes nothing to stderr"            "$ESCRIPT" "$SQUARE"
+
+assert_exit      "--max-dim accepted"               0  "$ESCRIPT" "$SQUARE" --max-dim 1
+assert_exit      "--threshold accepted"             0  "$ESCRIPT" "$SQUARE" --threshold 5.0
+
+# ── stream mode ─────────────────────────────────────────────────────────────
+stream_out=$("$ESCRIPT" --stream < "$SQUARE" 2>/dev/null)
+file_out=$("$ESCRIPT" "$SQUARE" 2>/dev/null)
+
+if echo "$stream_out" | grep -q "H1 (1 bar)"; then
+  pass "stream mode computes the barcode"
+else
+  fail "stream mode computes the barcode (got: $stream_out)"
+fi
+
+if [ "$stream_out" = "$file_out" ]; then
+  pass "stream and file modes agree"
+else
+  fail "stream and file modes agree"
+fi
+
+# ── error paths ─────────────────────────────────────────────────────────────
+assert_exit   "no args exits 1"              1  "$ESCRIPT"
+assert_stderr "no args prints error"         "no input file"  "$ESCRIPT"
+assert_exit   "unknown flag exits 1"         1  "$ESCRIPT" --bogus
+assert_exit   "missing file exits 1"         1  "$ESCRIPT" /nonexistent/points.txt
+assert_exit   "empty file exits 2"           2  "$ESCRIPT" "$EMPTY"
+
+# ── summary ─────────────────────────────────────────────────────────────────
+summary

--- a/test/support/sh_assert.sh
+++ b/test/support/sh_assert.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Shared assertions for the shell-level CLI suites (cli_test.sh, escript_test.sh).
+# Source this file, then call the assert_* helpers; finish with `summary`.
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+assert_exit() {
+  local desc="$1" expected="$2"
+  shift 2
+  local actual
+  actual=0
+  "$@" >/dev/null 2>&1 || actual=$?
+  if [ "$actual" -eq "$expected" ]; then pass "$desc"; else fail "$desc (expected exit $expected, got $actual)"; fi
+}
+
+assert_stdout() {
+  local desc="$1" pattern="$2"
+  shift 2
+  local out
+  out=$("$@" 2>/dev/null)
+  if echo "$out" | grep -q "$pattern"; then pass "$desc"; else fail "$desc (pattern '$pattern' not found in output)"; fi
+}
+
+assert_stderr() {
+  local desc="$1" pattern="$2"
+  shift 2
+  local err
+  err=$("$@" 2>&1 >/dev/null || true)
+  if echo "$err" | grep -q "$pattern"; then pass "$desc"; else fail "$desc (pattern '$pattern' not found in stderr)"; fi
+}
+
+assert_no_stderr() {
+  local desc="$1"
+  shift
+  local err
+  err=$("$@" 2>&1 >/dev/null || true)
+  if [ -z "$err" ]; then pass "$desc"; else fail "$desc (unexpected stderr: $err)"; fi
+}
+
+# Exits non-zero if anything failed, so the script can be used as a CI step.
+summary() {
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed"
+  [ "$FAIL" -eq 0 ]
+}


### PR DESCRIPTION
Closes #130.

## Problem

The escript could not start at all. `:exla` was a runtime dependency and an escript is a single archive, so `priv/libexla.so` is never on disk for the NIF loader — every invocation, including `--help`, died before `main/1` ran.

## Changes

- **Packaging.** `escript: [app: nil]` so the escript starts no applications of its own, and `cli/0` builds it with `MIX_ENV=prod`. EXLA moves to `only: [:dev, :test]`, so it is neither configured nor bundled in the escript.
- **`PhNx.Backend`.** Selects the CLI's backend explicitly: keeps the configured backend when it can actually be loaded and started, otherwise falls back to `Nx.BinaryBackend` with a single stderr warning instead of an Erlang crash report. `select/2` (pure decision, injectable probe) is split from `install/1` (effect) so the decision is testable without mutating global backend state. Selection is deferred to compute time, so `--help` and argument errors never depend on it.
- **`mix ph_nx` too.** The task also failed on machines with a broken XLA install — `app.start` crashed before the CLI ran. It now uses `--no-start` and lets `PhNx.Backend` start the accelerator only after confirming it works.
- **Regression cover.** `test/escript_test.sh` builds the escript and exercises it end to end (file mode, `--stream`, error exit codes, no bundled EXLA beams) and is wired into CI; `mix test` runs in-process and cannot catch packaging failures. Shell assertions shared with `cli_test.sh` moved to `test/support/sh_assert.sh`.
- **Docs.** README documents which backend each entry point uses and why.

## Acceptance criteria

| Criterion | Status |
|---|---|
| `./ph_nx --help` exits 0 without XLA present | ✅ no apps started; prod escript bundles no EXLA at all (asserted) |
| `./ph_nx points.csv` and `... \| ./ph_nx --stream` produce correct barcodes | ✅ both verified, and asserted to produce identical output |
| CI step builds and runs the escript end to end | ✅ `test/escript_test.sh`, 19 assertions |
| Backend selection documented in the README | ✅ "Backends used by the CLI" |

## Note on scope

`{:exla, only: [:dev, :test]}` means consumers no longer get EXLA transitively. The README already documented EXLA as opt-in ("Optionally add EXLA"), so this aligns code with documented intent — but it is a behaviour change for anyone relying on the transitive dependency.

## Verification

288 unit tests, 21 mix-CLI assertions, 19 escript assertions — all passing. Clean compile with `--warnings-as-errors` in dev and test.