### PR TITLE
fix: accept :on_progress and :coeff in batch compute/2 (closes #131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ PhNx.filtration_builder(points, max_dim: 1)
 | `:max_dim` | `2` | Maximum simplex dimension. To detect Hₖ features you need simplices up to dimension k+1. |
 | `:threshold` | enclosing radius | Ignore simplices born after this filtration value. The enclosing radius is the smallest value at which all points are connected. Pass `:infinity` to include all simplices. |
 | `:boundary_builder` | `BoundaryMatrix.build_from_filtration/2` | Override the boundary matrix constructor. Useful for testing and alternative implementations. Must be a 2-arity function `(filtration, opts) -> BoundaryMatrix.t()`. |
+| `:coeff` | `:z2` | Coefficient ring for the reduction. Pass `{:zp, p}` for ℤₚ arithmetic with signed boundary operators. |
+| `:on_progress` | none | 1-arity callback invoked once per column during reduction, receiving `%{current: non_neg_integer(), total: pos_integer()}`. |
+| `:backend` | `:cpu` | Distance computation backend (`:cpu` or `:gpu`). `PhNx.compute/2` only — not accepted by `PhNx.Persistence.compute/2`. |
 
 ## Modules
 

--- a/lib/ph_nx/persistence.ex
+++ b/lib/ph_nx/persistence.ex
@@ -53,6 +53,9 @@ defmodule PhNx.Persistence do
       `&BoundaryMatrix.build_from_filtration/2`): function used to construct the boundary
       matrix from the filtered simplex list. Override to inject alternative implementations
       (e.g. GPU-accelerated, pre-seeded, or test doubles).
+    - `coeff` — coefficient ring; `{:zp, p}` for ℤₚ arithmetic (default: ℤ₂).
+    - `on_progress` — 1-arity callback invoked once per column during reduction,
+      receiving `%{current: non_neg_integer(), total: pos_integer()}`.
 
   Returns a map:
     %{
@@ -63,7 +66,9 @@ defmodule PhNx.Persistence do
   """
   @spec compute(Nx.Tensor.t() | [[number()]], keyword()) :: result()
   def compute(points, opts \\ []) do
-    opts = Keyword.validate!(opts, [:max_dim, :threshold, :boundary_builder])
+    opts =
+      Keyword.validate!(opts, [:max_dim, :threshold, :boundary_builder, :coeff, :on_progress])
+
     max_dim = Keyword.get(opts, :max_dim, 2)
 
     if not is_integer(max_dim) or max_dim < 0 do
@@ -102,7 +107,7 @@ defmodule PhNx.Persistence do
     end
 
     builder_opts = Keyword.delete(opts, :boundary_builder)
-    reduced = builder.(filtration, builder_opts) |> BoundaryMatrix.reduce()
+    reduced = builder.(filtration, builder_opts) |> Reduction.reduce(builder_opts)
     raw_pairs = BoundaryMatrix.pairs(reduced)
     raw_essential = BoundaryMatrix.essential(reduced)
 

--- a/lib/ph_nx/topology.ex
+++ b/lib/ph_nx/topology.ex
@@ -16,7 +16,9 @@ defmodule PhNx.Topology do
           max_dim: non_neg_integer(),
           threshold: number() | :infinity,
           boundary_builder: (list(), keyword() -> BoundaryMatrix.t()),
-          backend: :cpu | :gpu
+          backend: :cpu | :gpu,
+          coeff: :z2 | {:zp, pos_integer()},
+          on_progress: (%{current: non_neg_integer(), total: pos_integer()} -> any())
         ]
 
   @doc """
@@ -33,12 +35,23 @@ defmodule PhNx.Topology do
       `:gpu` requires EXLA with a CUDA-capable device; falls back to CPU with a
       warning if the GPU is unavailable. Can also be set globally via
       `config :ph_nx, distance_backend: :gpu`.
+    - `:coeff` — coefficient ring; `{:zp, p}` for ℤₚ arithmetic (default: ℤ₂).
+    - `:on_progress` — 1-arity callback invoked once per column during reduction,
+      receiving `%{current: non_neg_integer(), total: pos_integer()}`.
 
   Returns `%{pairs: [...], essential: [...], diagram: [...]}`.
   """
   @spec compute(Nx.Tensor.t() | [[number()]], options()) :: PhNx.Persistence.result()
   def compute(points, opts \\ []) do
-    opts = Keyword.validate!(opts, [:max_dim, :threshold, :boundary_builder, :backend])
+    opts =
+      Keyword.validate!(opts, [
+        :max_dim,
+        :threshold,
+        :boundary_builder,
+        :backend,
+        :coeff,
+        :on_progress
+      ])
 
     max_dim = Keyword.get(opts, :max_dim, 2)
 
@@ -80,7 +93,7 @@ defmodule PhNx.Topology do
     end
 
     builder_opts = Keyword.delete(opts, :boundary_builder)
-    reduced = builder.(filtration, builder_opts) |> Reduction.reduce()
+    reduced = builder.(filtration, builder_opts) |> Reduction.reduce(builder_opts)
     raw_pairs = BoundaryMatrix.pairs(reduced)
     raw_essential = BoundaryMatrix.essential(reduced)
 

--- a/test/persistence_test.exs
+++ b/test/persistence_test.exs
@@ -38,6 +38,53 @@ defmodule PhNx.PersistenceTest do
     end
   end
 
+  describe "Persistence.compute/2 reduction options" do
+    test "honours :on_progress during reduction" do
+      test_pid = self()
+
+      Persistence.compute(@points,
+        on_progress: fn progress -> send(test_pid, {:progress, progress}) end
+      )
+
+      assert_received {:progress, %{current: 0, total: total}}
+      assert total > 0
+
+      seen =
+        for _ <- 1..(total - 1) do
+          assert_received {:progress, %{current: c, total: ^total}}
+          c
+        end
+
+      assert seen == Enum.to_list(1..(total - 1))
+      refute_received {:progress, _}
+    end
+
+    test ":coeff reaches the boundary matrix, which reduces over Zp" do
+      test_pid = self()
+
+      spy = fn filtration, opts ->
+        bm = BoundaryMatrix.build_from_filtration(filtration, opts)
+        send(test_pid, {:ring, bm.coeff_ring})
+        bm
+      end
+
+      Persistence.compute(@points, coeff: {:zp, 3}, boundary_builder: spy)
+      assert_received {:ring, {:zp, 3}}
+
+      Persistence.compute(@points, boundary_builder: spy)
+      assert_received {:ring, :z2}
+    end
+
+    test "Zp reduction agrees with the default Z2 reduction on the triangle" do
+      assert Persistence.compute(@points, coeff: {:zp, 3}) == Persistence.compute(@points)
+    end
+
+    test "results are unchanged when :on_progress is passed" do
+      assert Persistence.compute(@points, on_progress: fn _ -> :ok end) ==
+               Persistence.compute(@points)
+    end
+  end
+
   describe "Persistence.compute_stream/2" do
     test "produces same result as PhNx.compute/2 for a point cloud" do
       points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]

--- a/test/topology_test.exs
+++ b/test/topology_test.exs
@@ -93,6 +93,49 @@ defmodule PhNx.TopologyTest do
     end
   end
 
+  describe "PhNx.Topology.compute/2 reduction options" do
+    test ":on_progress is invoked once per reduction column" do
+      test_pid = self()
+
+      PhNx.compute(@square, on_progress: fn progress -> send(test_pid, {:progress, progress}) end)
+
+      assert_received {:progress, %{current: 0, total: total}}
+
+      seen =
+        for _ <- 1..(total - 1) do
+          assert_received {:progress, %{current: c, total: ^total}}
+          c
+        end
+
+      assert seen == Enum.to_list(1..(total - 1))
+      refute_received {:progress, _}
+    end
+
+    test ":coeff reaches the boundary matrix, which reduces over Zp" do
+      test_pid = self()
+
+      spy = fn filtration, opts ->
+        bm = PhNx.BoundaryMatrix.build_from_filtration(filtration, opts)
+        send(test_pid, {:ring, bm.coeff_ring})
+        bm
+      end
+
+      PhNx.compute(@square, coeff: {:zp, 3}, boundary_builder: spy)
+      assert_received {:ring, {:zp, 3}}
+
+      PhNx.compute(@square, boundary_builder: spy)
+      assert_received {:ring, :z2}
+    end
+
+    test "Zp reduction agrees with the default Z2 reduction on the square" do
+      assert PhNx.compute(@square, coeff: {:zp, 3}) == PhNx.compute(@square)
+    end
+
+    test "results are unchanged when :on_progress is passed" do
+      assert PhNx.compute(@square, on_progress: fn _ -> :ok end) == PhNx.compute(@square)
+    end
+  end
+
   describe "PhNx.compute/2 public API" do
     test "still works and returns correct result (no breaking change)" do
       result = PhNx.compute(@square)


### PR DESCRIPTION
Closes #131.

Both batch entry points rejected the options that `PhNx.Reduction.reduce/2` documents, so the progress callback added in #105 was unreachable from the public `PhNx.compute/2` API.

## Changes

Two distinct defects per call site, as the issue describes:

- **Whitelists** — `PhNx.Topology.compute/2` (`topology.ex:41`) and `PhNx.Persistence.compute/2` (`persistence.ex:69`) now accept `:coeff` and `:on_progress`.
- **Reduction call** — both paths now pass `builder_opts` into the reduction (`topology.ex:90`, `persistence.ex:110`), matching `compute_stream/2` (2e48e44). The whitelist alone fixes `:coeff`, since `builder_opts` was already threaded into the builder; `:on_progress` additionally needs the reduce call to receive the options.
- **Docs** — both moduledocs, the `Topology.options()` type, and the README options table (which also gains the previously undocumented `:backend` row).

## Acceptance criteria

- [x] `PhNx.compute(pts, on_progress: cb)` invokes `cb` once per reduction column
- [x] `PhNx.compute(pts, coeff: {:zp, 3})` performs ℤₚ reduction
- [x] Same for `PhNx.Persistence.compute/2`
- [x] Results unchanged when neither option is passed
- [x] Tests cover both options on both entry points

## Testing

Written test-first; all four `ArgumentError`s from the issue were reproduced before the fix. Full suite: 296 tests, 0 failures.

The `:coeff` tests use a `boundary_builder` spy asserting the built matrix's `coeff_ring`. A result-level assertion would not work here: the ℤ₂ and ℤ₃ diagrams are identical on these point clouds, so a test comparing diagrams would pass even if `:coeff` were silently dropped.

## Not addressed

The issue's open question about whether two near-identical batch `compute/2` implementations should continue to exist is left for a follow-up. Relatedly, the option list is now duplicated across three `Keyword.validate!` calls — a shared module attribute would make the next option a one-line change.