### PR TITLE
Add README pipeline diagram; isolate distance-backend config test

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,41 @@ PhNx.filtration_builder(points, max_dim: 1)
 | `:on_progress` | none | 1-arity callback invoked once per column during reduction, receiving `%{current: non_neg_integer(), total: pos_integer()}`. |
 | `:backend` | `:cpu` | Distance computation backend (`:cpu` or `:gpu`). `PhNx.compute/2` only — not accepted by `PhNx.Persistence.compute/2`. |
 
+## Architecture
+
+Each stage is a deep module behind a small interface, so it can be tested and replaced
+on its own. `PhNx.Topology` is the façade that wires them together and keeps
+`PhNx.compute/2` stable.
+
+```mermaid
+flowchart TD
+    PC["point cloud<br/>Nx.Tensor or [[number]]"] --> API
+    ST["point stream<br/>Enumerable"] --> API
+
+    API["PhNx<br/>compute/2 · compute_stream/2"]
+
+    subgraph PIPE["PhNx.Topology — façade"]
+        direction TB
+        DIST["PhNx.Distance<br/>pairwise Euclidean matrix<br/>:backend"]
+        FILT["PhNx.FiltrationBuilder → PhNx.Filtration<br/>Vietoris-Rips complex<br/>:max_dim · :threshold"]
+        BND["PhNx.BoundaryMatrix<br/>sparse boundary matrix<br/>:coeff · :boundary_builder"]
+        RED["PhNx.Reduction<br/>column reduction → pairs<br/>:coeff · :on_progress"]
+        DIST --> FILT --> BND --> RED
+    end
+
+    API --> DIST
+    RED --> RES["%{pairs, essential, diagram}"]
+    RES --> OUT["PhNx.Persistence<br/>print_barcode/1 · betti_numbers/1 · most_persistent/2"]
+```
+
+Two details the diagram flattens:
+
+- `compute_stream/2` realises the enumerable in full before the distance matrix is
+  built — every point is needed for pairwise distances — and it runs through
+  `PhNx.Persistence`, which reproduces the same stages without the `:backend` option.
+- `:threshold` defaults to the enclosing radius computed from the distance matrix, so
+  the filtration stage depends on the distance stage for more than just its input.
+
 ## Modules
 
 | Module | Responsibility |

--- a/test/distance_backend_config_test.exs
+++ b/test/distance_backend_config_test.exs
@@ -1,0 +1,24 @@
+defmodule PhNx.DistanceBackendConfigTest do
+  # Not async: these tests set :ph_nx, :distance_backend, which is global state
+  # that any other test calling Distance.euclidean/1 would observe (issue #126).
+  use ExUnit.Case, async: false
+
+  alias PhNx.Distance
+
+  @pts Nx.tensor([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+
+  setup do
+    on_exit(fn -> Application.delete_env(:ph_nx, :distance_backend) end)
+  end
+
+  describe "app config :distance_backend" do
+    test ":gpu config produces correct distances" do
+      Application.put_env(:ph_nx, :distance_backend, :gpu)
+
+      result = Distance.euclidean(@pts)
+      assert Nx.shape(result) == {3, 3}
+      mat = Nx.to_list(result)
+      assert_in_delta Enum.at(Enum.at(mat, 0), 1), 1.0, 1.0e-9
+    end
+  end
+end

--- a/test/distance_backend_test.exs
+++ b/test/distance_backend_test.exs
@@ -30,19 +30,4 @@ defmodule PhNx.DistanceBackendTest do
                "GPU backend unavailable, falling back to CPU"
     end
   end
-
-  describe "app config :distance_backend" do
-    test ":gpu config produces correct distances" do
-      Application.put_env(:ph_nx, :distance_backend, :gpu)
-
-      try do
-        result = Distance.euclidean(@pts)
-        assert Nx.shape(result) == {3, 3}
-        mat = Nx.to_list(result)
-        assert_in_delta Enum.at(Enum.at(mat, 0), 1), 1.0, 1.0e-9
-      after
-        Application.delete_env(:ph_nx, :distance_backend)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Closes #108, closes #126.

## #126 — async test isolation

`PhNx.DistanceBackendTest` was `async: true` while its "app config" test set `:ph_nx, :distance_backend` to `:gpu` — global state that any concurrently-scheduled async test calling `Distance.euclidean/1` could observe. The `after` block closed the window but did not eliminate it.

That one test moves to `test/distance_backend_config_test.exs` with `async: false`; the other three stay async since they pass `backend:` explicitly and touch nothing global. Cleanup switched from `try/after` to `on_exit`.

## #108 — README architecture diagram

The `## Modules` table listed responsibilities but not data flow. Added a Mermaid flowchart above it showing the stages and where each option enters the pipeline.

I traced the call graph in `lib/` rather than working from the PRD text, which corrected two things:

- The pipeline is **five** stages. `PhNx.BoundaryMatrix` sits between `FiltrationBuilder` and `Reduction`, and is where `:coeff` and `:boundary_builder` actually apply. The PRD's `Distance → FiltrationBuilder → Reduction` sketch omits it.
- `compute_stream/2` does **not** go through `Topology` — it runs `Persistence.compute_stream/2`, which reproduces the stages via `Filtration.build` and rejects `:backend`. Drawing it as a parallel track hurt readability, so it is called out in prose under the diagram, together with `:threshold` defaulting to the enclosing radius derived from the distance matrix.

## Verification

`mix format --check-formatted` clean; `mix test` 296 tests, 0 failures. The async/sync split is visible in the timing (10.2s async, 4.4s sync).

## Not done here

- The Mermaid syntax has not been rendered — worth a look at the diff preview on this PR.
- The `## Modules` table still calls `Topology` an orchestrator of "Distance → FiltrationBuilder → Reduction", which now sits directly below a diagram showing five stages. Left alone as out of scope for #108, but it should be corrected.